### PR TITLE
Introduce `--format` flag to conditionally generate SARIF report

### DIFF
--- a/docs/static-code-analysis-tool/README.md
+++ b/docs/static-code-analysis-tool/README.md
@@ -79,13 +79,13 @@ bal scan --target-dir="results"
 bal scan --scan-report
 ```
 
-5. Run analysis and specify the output format (json or sarif).
+5. Run analysis and specify the output format (ballerina or sarif).
 
 ```bash
 bal scan --format=sarif
 ```
 
-> Note: The default format is json. The tool supports both json and sarif formats for analysis results.
+> Note: The default format is ballerina. The tool supports both ballerina and sarif formats for analysis results.
 
 6. View all available rules.
 

--- a/docs/static-code-analysis-tool/README.md
+++ b/docs/static-code-analysis-tool/README.md
@@ -74,41 +74,50 @@ bal scan --target-dir="results"
 ```
 
 4. Run analysis and generate a HTML analysis report.
+
 ```bash
 bal scan --scan-report
 ```
 
-5. View all available rules.
+5. Run analysis and specify the output format (json or sarif).
+
+```bash
+bal scan --format=sarif
+```
+
+> Note: The default format is json. The tool supports both json and sarif formats for analysis results.
+
+6. View all available rules.
 
 ```bash
 bal scan --list-rules
 ```
 
-6. Run analysis for a specific rule.
+7. Run analysis for a specific rule.
 
 ```bash
 bal scan --include-rules="ballerina:101"
 ```
 
-7. Run analysis for a specific set of rules.
+8. Run analysis for a specific set of rules.
 
 ```bash
 bal scan --include-rules="ballerina:101, ballerina/io:101"
 ```
 
-8. Exclude analysis for a specific rule.
+9. Exclude analysis for a specific rule.
 
 ```bash
 bal scan --exclude-rules="ballerina:101"
 ```
 
-9. Exclude analysis for a specific set of rules.
+10. Exclude analysis for a specific set of rules.
 
 ```bash
 bal scan --exclude-rules="ballerina:101, ballerina/io:101"
 ```
 
-10. Run analysis and report to a static analysis platform (e.g., SonarQube).
+11. Run analysis and report to a static analysis platform (e.g., SonarQube).
 
 ```bash
 bal scan --platforms=sonarqube
@@ -116,13 +125,13 @@ bal scan --platforms=sonarqube
 
 > Note: If the Platform Plugin path is not provided in a `Scan.toml` file, the tool will attempt to download the Platform Plugin for plugins developed by the Ballerina team.
 
-11. Run analysis and report to multiple static analysis platforms.
+12. Run analysis and report to multiple static analysis platforms.
 
 ```bash
 bal scan --platforms="sonarqube, semgrep, codeql"
 ```
 
-12. Configuring the tool's behavior using a configuration file. (e.g., `Scan.toml`)
+13. Configuring the tool's behavior using a configuration file. (e.g., `Scan.toml`)
 
 ```md
 📦ballerina_project

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=io.ballerina.scan
-version=0.10.1-SNAPSHOT
+version=0.11.0-SNAPSHOT
 
 # Plugin versions
 spotbugsPluginVersion=6.1.5

--- a/scan-command-test-utils/src/main/java/io/ballerina/scan/test/TestOptions.java
+++ b/scan-command-test-utils/src/main/java/io/ballerina/scan/test/TestOptions.java
@@ -19,6 +19,7 @@
 package io.ballerina.scan.test;
 
 import io.ballerina.projects.Project;
+import io.ballerina.scan.ReportFormat;
 import io.ballerina.scan.Rule;
 
 import java.io.PrintStream;
@@ -37,15 +38,15 @@ public class TestOptions {
     private final boolean platformTriggered;
     private final String targetDir;
     private final boolean scanReport;
-    private final String format;
+    private final ReportFormat format;
     private final boolean listRules;
     private final List<Rule> includeRules;
     private final List<Rule> excludeRules;
     private final List<String> platforms;
 
     private TestOptions(Project project, PrintStream outputStream, boolean helpFlag, boolean platformTriggered,
-            String targetDir, boolean scanReport, String format, boolean listRules, List<Rule> includeRules,
-            List<Rule> excludeRules, List<String> platforms) {
+                        String targetDir, boolean scanReport, ReportFormat format, boolean listRules,
+                        List<Rule> includeRules, List<Rule> excludeRules, List<String> platforms) {
         this.project = project;
         this.outputStream = outputStream;
         this.helpFlag = helpFlag;
@@ -128,7 +129,7 @@ public class TestOptions {
      *
      * @return the format of the report
      */
-    String format() {
+    ReportFormat format() {
         return format;
     }
 
@@ -175,7 +176,7 @@ public class TestOptions {
         private boolean platformTriggered;
         private String targetDir;
         private boolean scanReport;
-        private String format;
+        private ReportFormat format;
         private boolean listRules;
         private List<Rule> includeRules = List.of();
         private List<Rule> excludeRules = List.of();
@@ -191,6 +192,7 @@ public class TestOptions {
          * @param outputStream the output stream
          * @return this builder
          */
+        @SuppressWarnings("unused")
         public TestOptionsBuilder setOutputStream(PrintStream outputStream) {
             this.outputStream = outputStream;
             return this;
@@ -202,6 +204,7 @@ public class TestOptions {
          * @param helpFlag true if the help flag needs to be enabled, false otherwise
          * @return this builder
          */
+        @SuppressWarnings("unused")
         public TestOptionsBuilder setHelpFlag(boolean helpFlag) {
             this.helpFlag = helpFlag;
             return this;
@@ -214,6 +217,7 @@ public class TestOptions {
          *                          otherwise
          * @return this builder
          */
+        @SuppressWarnings("unused")
         public TestOptionsBuilder setPlatformTriggered(boolean platformTriggered) {
             this.platformTriggered = platformTriggered;
             return this;
@@ -225,6 +229,7 @@ public class TestOptions {
          * @param targetDir the target directory
          * @return this builder
          */
+        @SuppressWarnings("unused")
         public TestOptionsBuilder setTargetDir(String targetDir) {
             this.targetDir = targetDir;
             return this;
@@ -237,6 +242,7 @@ public class TestOptions {
          *                   otherwise
          * @return this builder
          */
+        @SuppressWarnings("unused")
         public TestOptionsBuilder setScanReport(boolean scanReport) {
             this.scanReport = scanReport;
             return this;
@@ -248,8 +254,21 @@ public class TestOptions {
          * @param format the format of the report
          * @return this builder
          */
-        public TestOptionsBuilder setFormat(String format) {
+        @SuppressWarnings("unused")
+        public TestOptionsBuilder setFormat(ReportFormat format) {
             this.format = format;
+            return this;
+        }
+
+        /**
+         * Set the format of the report using string value.
+         *
+         * @param format the format string value
+         * @return this builder
+         */
+        @SuppressWarnings("unused")
+        public TestOptionsBuilder setFormat(String format) {
+            this.format = ReportFormat.fromString(format);
             return this;
         }
 
@@ -259,6 +278,7 @@ public class TestOptions {
          * @param listRules true if the rules should be listed, false otherwise
          * @return this builder
          */
+        @SuppressWarnings("unused")
         public TestOptionsBuilder setListRules(boolean listRules) {
             this.listRules = listRules;
             return this;
@@ -270,6 +290,7 @@ public class TestOptions {
          * @param includeRules the list of rules to be included
          * @return this builder
          */
+        @SuppressWarnings("unused")
         public TestOptionsBuilder setIncludeRules(List<Rule> includeRules) {
             this.includeRules = Collections.unmodifiableList(includeRules);
             return this;
@@ -281,6 +302,7 @@ public class TestOptions {
          * @param excludeRules the list of rules to be excluded
          * @return this builder
          */
+        @SuppressWarnings("unused")
         public TestOptionsBuilder setExcludeRules(List<Rule> excludeRules) {
             this.excludeRules = Collections.unmodifiableList(excludeRules);
             return this;
@@ -292,6 +314,7 @@ public class TestOptions {
          * @param platforms the list of platforms
          * @return this builder
          */
+        @SuppressWarnings("unused")
         public TestOptionsBuilder setPlatforms(List<String> platforms) {
             this.platforms = Collections.unmodifiableList(platforms);
             return this;
@@ -302,6 +325,7 @@ public class TestOptions {
          *
          * @return the built {@code TestOptions} instance
          */
+        @SuppressWarnings("unused")
         public TestOptions build() {
             return new TestOptions(project, outputStream, helpFlag, platformTriggered,
                     targetDir, scanReport, format, listRules, includeRules, excludeRules, platforms);

--- a/scan-command-test-utils/src/main/java/io/ballerina/scan/test/TestOptions.java
+++ b/scan-command-test-utils/src/main/java/io/ballerina/scan/test/TestOptions.java
@@ -37,20 +37,22 @@ public class TestOptions {
     private final boolean platformTriggered;
     private final String targetDir;
     private final boolean scanReport;
+    private final String format;
     private final boolean listRules;
     private final List<Rule> includeRules;
     private final List<Rule> excludeRules;
     private final List<String> platforms;
 
     private TestOptions(Project project, PrintStream outputStream, boolean helpFlag, boolean platformTriggered,
-                        String targetDir, boolean scanReport, boolean listRules, List<Rule> includeRules,
-                        List<Rule> excludeRules, List<String> platforms) {
+            String targetDir, boolean scanReport, String format, boolean listRules, List<Rule> includeRules,
+            List<Rule> excludeRules, List<String> platforms) {
         this.project = project;
         this.outputStream = outputStream;
         this.helpFlag = helpFlag;
         this.platformTriggered = platformTriggered;
         this.targetDir = targetDir;
         this.scanReport = scanReport;
+        this.format = format;
         this.listRules = listRules;
         this.includeRules = includeRules;
         this.excludeRules = excludeRules;
@@ -72,9 +74,9 @@ public class TestOptions {
      *
      * @return the project to be scanned
      */
-     Project project() {
+    Project project() {
         return project;
-     }
+    }
 
     /**
      * Get the output stream.
@@ -122,6 +124,15 @@ public class TestOptions {
     }
 
     /**
+     * Get the format of the report.
+     *
+     * @return the format of the report
+     */
+    String format() {
+        return format;
+    }
+
+    /**
      * Get if the rules should be listed or not.
      *
      * @return true if the rules should be listed, false otherwise
@@ -164,6 +175,7 @@ public class TestOptions {
         private boolean platformTriggered;
         private String targetDir;
         private boolean scanReport;
+        private String format;
         private boolean listRules;
         private List<Rule> includeRules = List.of();
         private List<Rule> excludeRules = List.of();
@@ -198,7 +210,8 @@ public class TestOptions {
         /**
          * Set if the scan is triggered by a platform.
          *
-         * @param platformTriggered true if the scan is triggered by a platform, false otherwise
+         * @param platformTriggered true if the scan is triggered by a platform, false
+         *                          otherwise
          * @return this builder
          */
         public TestOptionsBuilder setPlatformTriggered(boolean platformTriggered) {
@@ -220,11 +233,23 @@ public class TestOptions {
         /**
          * Set if the scan report needs to be enabled.
          *
-         * @param scanReport true if the scan report needs to be enabled, false otherwise
+         * @param scanReport true if the scan report needs to be enabled, false
+         *                   otherwise
          * @return this builder
          */
         public TestOptionsBuilder setScanReport(boolean scanReport) {
             this.scanReport = scanReport;
+            return this;
+        }
+
+        /**
+         * Set the format of the report.
+         *
+         * @param format the format of the report
+         * @return this builder
+         */
+        public TestOptionsBuilder setFormat(String format) {
+            this.format = format;
             return this;
         }
 
@@ -279,7 +304,7 @@ public class TestOptions {
          */
         public TestOptions build() {
             return new TestOptions(project, outputStream, helpFlag, platformTriggered,
-                    targetDir, scanReport, listRules, includeRules, excludeRules, platforms);
+                    targetDir, scanReport, format, listRules, includeRules, excludeRules, platforms);
         }
     }
 }

--- a/scan-command-test-utils/src/main/java/io/ballerina/scan/test/TestScanCmd.java
+++ b/scan-command-test-utils/src/main/java/io/ballerina/scan/test/TestScanCmd.java
@@ -32,7 +32,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Optional;
 
-import static io.ballerina.scan.ReportFormat.JSON;
+import static io.ballerina.scan.ReportFormat.BALLERINA;
 
 /**
  * TestScanCmd extends ScanCmd to extend it for testing purposes.
@@ -67,7 +67,7 @@ public class TestScanCmd extends ScanCmd {
                 false,
                 null,
                 false,
-                JSON,
+                BALLERINA,
                 false,
                 Collections.emptyList(),
                 Collections.emptyList(),

--- a/scan-command-test-utils/src/main/java/io/ballerina/scan/test/TestScanCmd.java
+++ b/scan-command-test-utils/src/main/java/io/ballerina/scan/test/TestScanCmd.java
@@ -49,11 +49,11 @@ public class TestScanCmd extends ScanCmd {
                 options.platformTriggered(),
                 options.targetDir(),
                 options.scanReport(),
+                options.format(),
                 options.listRules(),
                 options.includeRules(),
                 options.excludeRules(),
-                options.platforms()
-        );
+                options.platforms());
         this.project = options.project();
     }
 
@@ -65,11 +65,11 @@ public class TestScanCmd extends ScanCmd {
                 false,
                 null,
                 false,
+                "json",
                 false,
                 Collections.emptyList(),
                 Collections.emptyList(),
-                Collections.emptyList()
-        );
+                Collections.emptyList());
         if (projectPath.toFile().isDirectory()) {
             project = BuildProject.load(getEnvironmentBuilder(distributionPath), projectPath);
         } else {

--- a/scan-command-test-utils/src/main/java/io/ballerina/scan/test/TestScanCmd.java
+++ b/scan-command-test-utils/src/main/java/io/ballerina/scan/test/TestScanCmd.java
@@ -32,6 +32,8 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Optional;
 
+import static io.ballerina.scan.ReportFormat.JSON;
+
 /**
  * TestScanCmd extends ScanCmd to extend it for testing purposes.
  *
@@ -65,7 +67,7 @@ public class TestScanCmd extends ScanCmd {
                 false,
                 null,
                 false,
-                "json",
+                JSON,
                 false,
                 Collections.emptyList(),
                 Collections.emptyList(),

--- a/scan-command/build.gradle
+++ b/scan-command/build.gradle
@@ -86,6 +86,18 @@ tasks.withType(JavaExec).configureEach {
     systemProperty 'ballerina.home', System.getenv("BALLERINA_HOME")
 }
 
+// Inject version into properties file during build
+processResources {
+    filesMatching('**/version.properties') {
+        expand(project.properties)
+    }
+    doLast {
+        def versionPropsFile = new File(sourceSets.main.output.resourcesDir, 'version.properties')
+        versionPropsFile.parentFile.mkdirs()
+        versionPropsFile.text = "app.version=${version}\n"
+    }
+}
+
 // Setting up checkstyles
 tasks.register('downloadCheckstyleRuleFiles', Download) {
     src([

--- a/scan-command/src/main/java/io/ballerina/scan/ReportFormat.java
+++ b/scan-command/src/main/java/io/ballerina/scan/ReportFormat.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.scan;
+
+/**
+ * Enum representing the report formats supported by the scan command.
+ *
+ * @since 0.10.0
+ */
+public enum ReportFormat {
+    JSON("json"),
+    SARIF("sarif");
+
+    private final String format;
+
+    ReportFormat(String format) {
+        this.format = format;
+    }
+
+    /**
+     * Returns the format string of the report format.
+     *
+     * @return the format string
+     */
+    public String getFormat() {
+        return format;
+    }
+
+    /**
+     * Returns the ReportFormat enum constant corresponding to the given format string.
+     *
+     * @param format the format string
+     * @return the corresponding ReportFormat enum constant
+     * @throws IllegalArgumentException if the format string does not match any known format
+     */
+    public static ReportFormat fromString(String format) {
+        for (ReportFormat reportFormat : values()) {
+            if (reportFormat.getFormat().equalsIgnoreCase(format)) {
+                return reportFormat;
+            }
+        }
+        throw new IllegalArgumentException("Unknown report format: " + format);
+    }
+}

--- a/scan-command/src/main/java/io/ballerina/scan/ReportFormat.java
+++ b/scan-command/src/main/java/io/ballerina/scan/ReportFormat.java
@@ -21,7 +21,7 @@ package io.ballerina.scan;
 /**
  * Enum representing the report formats supported by the scan command.
  *
- * @since 0.10.0
+ * @since 0.11.0
  */
 public enum ReportFormat {
     BALLERINA("ballerina"),

--- a/scan-command/src/main/java/io/ballerina/scan/ReportFormat.java
+++ b/scan-command/src/main/java/io/ballerina/scan/ReportFormat.java
@@ -24,7 +24,7 @@ package io.ballerina.scan;
  * @since 0.10.0
  */
 public enum ReportFormat {
-    JSON("json"),
+    BALLERINA("ballerina"),
     SARIF("sarif");
 
     private final String format;

--- a/scan-command/src/main/java/io/ballerina/scan/internal/ScanCmd.java
+++ b/scan-command/src/main/java/io/ballerina/scan/internal/ScanCmd.java
@@ -247,9 +247,11 @@ public class ScanCmd implements BLauncherCmd {
             ScanUtils.printToConsole(issues, outputStream);
             if (project.get().kind().equals(ProjectKind.BUILD_PROJECT)) {
                 Path reportPath = ScanUtils.saveToDirectory(issues, project.get(), targetDir);
+                Path sarifReportPath = reportPath.getParent().resolve("scan_results.sarif");
                 outputStream.println();
                 outputStream.println("View scan results at:");
-                outputStream.println("\t" + reportPath.toUri() + System.lineSeparator());
+                outputStream.println("\t" + reportPath.toUri());
+                outputStream.println("\t" + sarifReportPath.toUri() + System.lineSeparator());
                 if (scanReport) {
                     Path scanReportPath = ScanUtils.generateScanReport(issues, project.get(), targetDir);
                     outputStream.println();

--- a/scan-command/src/main/java/io/ballerina/scan/internal/ScanCmd.java
+++ b/scan-command/src/main/java/io/ballerina/scan/internal/ScanCmd.java
@@ -86,9 +86,9 @@ public class ScanCmd implements BLauncherCmd {
     private boolean scanReport;
 
     @CommandLine.Option(names = "--format",
-            description = "Specify the format of the report (json/sarif). Default is json",
+            description = "Specify the format of the report (ballerina/sarif). Default is ballerina",
             converter = ReportFormatConverter.class)
-    private ReportFormat format = ReportFormat.JSON;
+    private ReportFormat format = ReportFormat.BALLERINA;
 
     @CommandLine.Option(names = "--list-rules", description = "List the rules available in the Ballerina scan tool")
     private boolean listRules;

--- a/scan-command/src/main/java/io/ballerina/scan/utils/Constants.java
+++ b/scan-command/src/main/java/io/ballerina/scan/utils/Constants.java
@@ -25,6 +25,7 @@ package io.ballerina.scan.utils;
  */
 public class Constants {
     static final String RESULTS_JSON_FILE = "scan_results.json";
+    static final String RESULTS_SARIF_FILE = "scan_results.sarif";
     static final String RESULTS_HTML_FILE = "index.html";
     static final String REPORT_DATA_PLACEHOLDER = "__data__";
     static final String SCAN_REPORT_PROJECT_NAME = "projectName";
@@ -75,6 +76,7 @@ public class Constants {
         public static final String ZERO = "0";
         public static final String ONE = "1";
         public static final String MINUS_ONE = "-1";
+
         private Token() {
         }
     }

--- a/scan-command/src/main/java/io/ballerina/scan/utils/Constants.java
+++ b/scan-command/src/main/java/io/ballerina/scan/utils/Constants.java
@@ -64,6 +64,13 @@ public class Constants {
     static final String[] RULE_PRIORITY_LIST = {"ballerina", "ballerinax", "wso2"};
     public static final String MAIN_FUNCTION = "main";
     public static final String INIT_FUNCTION = "init";
+    public static final String SARIF_VERSION = "2.1.0";
+    public static final String SARIF_SCHEMA = "https://www.schemastore.org/schemas/json/" +
+            "sarif-2.1.0.json";
+    public static final String SARIF_TOOL_NAME = "Ballerina Scan Tool";
+    public static final String SARIF_TOOL_ORGANIZATION = "WSO2";
+    public static final String SARIF_TOOL_VERSION = "0.10.0";
+    public static final String SARIF_TOOL_URI = "https://central.ballerina.io/ballerina/tool_scan/";
 
     public static class Token {
         public static final String FLOAT = "float";

--- a/scan-command/src/main/java/io/ballerina/scan/utils/Constants.java
+++ b/scan-command/src/main/java/io/ballerina/scan/utils/Constants.java
@@ -18,6 +18,10 @@
 
 package io.ballerina.scan.utils;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
 /**
  * {@code Constants} contains the constants used by the scan tool utilities.
  *
@@ -69,8 +73,22 @@ public class Constants {
             "sarif-2.1.0.json";
     public static final String SARIF_TOOL_NAME = "Ballerina Scan Tool";
     public static final String SARIF_TOOL_ORGANIZATION = "WSO2";
-    public static final String SARIF_TOOL_VERSION = "0.10.0";
+    public static final String SARIF_TOOL_VERSION = getAppVersion();
     public static final String SARIF_TOOL_URI = "https://central.ballerina.io/ballerina/tool_scan/";
+
+    private static String getAppVersion() {
+        try (InputStream input = Constants.class.getClassLoader().getResourceAsStream("version.properties")) {
+            if (input != null) {
+                Properties props = new Properties();
+                props.load(input);
+                return props.getProperty("app.version", "0.1.0");
+            }
+        } catch (IOException ex) {
+            DiagnosticLog.error(DiagnosticCode.FAILED_TO_LOAD_VERSION_PROPERTIES,
+                    ex.getMessage());
+        }
+        return System.getProperty("app.version", "0.1.0");
+    }
 
     public static class Token {
         public static final String FLOAT = "float";

--- a/scan-command/src/main/java/io/ballerina/scan/utils/DiagnosticCode.java
+++ b/scan-command/src/main/java/io/ballerina/scan/utils/DiagnosticCode.java
@@ -40,6 +40,7 @@ public enum DiagnosticCode {
     FAILED_TO_COPY_SCAN_REPORT("STATIC_ANALYSIS_ERROR_014", "failed.to.copy.scan.report"),
     RULE_NOT_FOUND("STATIC_ANALYSIS_ERROR_015", "rule.not.found"),
     ATTEMPT_TO_INCLUDE_AND_EXCLUDE("STATIC_ANALYSIS_ERROR_016", "attempt.to.include.and.exclude"),
+    INVALID_FORMAT("STATIC_ANALYSIS_ERROR_017", "invalid.format"),
     REPORT_NOT_SUPPORTED("STATIC_ANALYSIS_WARNING_001", "report.not.supported"),
     SCAN_REPORT_NOT_SUPPORTED("STATIC_ANALYSIS_WARNING_002", "scan.report.not.supported");
 

--- a/scan-command/src/main/java/io/ballerina/scan/utils/DiagnosticCode.java
+++ b/scan-command/src/main/java/io/ballerina/scan/utils/DiagnosticCode.java
@@ -41,6 +41,7 @@ public enum DiagnosticCode {
     RULE_NOT_FOUND("STATIC_ANALYSIS_ERROR_015", "rule.not.found"),
     ATTEMPT_TO_INCLUDE_AND_EXCLUDE("STATIC_ANALYSIS_ERROR_016", "attempt.to.include.and.exclude"),
     INVALID_FORMAT("STATIC_ANALYSIS_ERROR_017", "invalid.format"),
+    FAILED_TO_LOAD_VERSION_PROPERTIES("STATIC_ANALYSIS_ERROR_018", "failed.to.load.version.properties"),
     REPORT_NOT_SUPPORTED("STATIC_ANALYSIS_WARNING_001", "report.not.supported"),
     SCAN_REPORT_NOT_SUPPORTED("STATIC_ANALYSIS_WARNING_002", "scan.report.not.supported");
 

--- a/scan-command/src/main/java/io/ballerina/scan/utils/ScanUtils.java
+++ b/scan-command/src/main/java/io/ballerina/scan/utils/ScanUtils.java
@@ -138,7 +138,7 @@ public final class ScanUtils {
      *
      * @param issues       generated issues
      * @param outputStream print stream
-     * @param printSarif   whether to print SARIF format instead of JSON
+     * @param printSarif   whether to print SARIF format instead of default BALLERINA format
      * @param project      Ballerina project (required for SARIF format)
      */
     public static void printToConsole(List<Issue> issues, PrintStream outputStream, boolean printSarif,

--- a/scan-command/src/main/java/io/ballerina/scan/utils/ScanUtils.java
+++ b/scan-command/src/main/java/io/ballerina/scan/utils/ScanUtils.java
@@ -58,9 +58,11 @@ import java.nio.file.Paths;
 import java.util.AbstractMap;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
@@ -196,6 +198,7 @@ public final class ScanUtils {
         // Create rules array for the tool
         JsonArray rules = new JsonArray();
         Map<String, JsonObject> ruleMap = new HashMap<>();
+        Set<String> addedRuleIds = new HashSet<>();
 
         // Collect unique rules from issues
         for (Issue issue : issues) {
@@ -221,7 +224,7 @@ public final class ScanUtils {
 
                 return obj;
             });
-            if (!rules.contains(ruleObject)) {
+            if (addedRuleIds.add(ruleId)) {
                 rules.add(ruleObject);
             }
         }

--- a/scan-command/src/main/java/io/ballerina/scan/utils/ScanUtils.java
+++ b/scan-command/src/main/java/io/ballerina/scan/utils/ScanUtils.java
@@ -112,6 +112,7 @@ import static io.ballerina.scan.utils.Constants.SCAN_REPORT_PROJECT_NAME;
 import static io.ballerina.scan.utils.Constants.SCAN_REPORT_SCANNED_FILES;
 import static io.ballerina.scan.utils.Constants.SCAN_REPORT_ZIP_FILE;
 import static io.ballerina.scan.utils.Constants.SCAN_TABLE;
+import static java.util.Locale.ROOT;
 
 /**
  * {@code ScanUtils} contains all the utility functions used by the scan tool.
@@ -205,8 +206,8 @@ public final class ScanUtils {
                 JsonObject obj = new JsonObject();
                 obj.addProperty("id", id);
 
-                // Construct helpUri based on rule ID format
-                String helpUri = constructHelpUri(id, issueImpl.rule().numericId());
+                // Construct helpUri based on rule ID and description
+                String helpUri = constructHelpUri(id, issueImpl.rule().description());
                 obj.addProperty("helpUri", helpUri);
 
                 JsonObject shortDescription = new JsonObject();
@@ -279,34 +280,22 @@ public final class ScanUtils {
     }
 
     /**
-     * Constructs the helpUri based on rule ID format.
+     * Constructs the helpUri based on rule ID and description.
      *
      * @param ruleId the rule ID
-     * @param numericId the numeric ID of the rule
+     * @param description the rule description
      * @return the constructed helpUri
      */
-    private static String constructHelpUri(String ruleId, int numericId) {
+    private static String constructHelpUri(String ruleId, String description) {
         String baseUri = SARIF_TOOL_URI + SARIF_TOOL_VERSION;
-        String[] parts = ruleId.split(":");
-
-        if (ruleId.contains("/")) {
-            // Standard library rule format: ballerina/module:numericId -> #rules-ballerina-module-numericId
-            if (parts.length == 2) {
-                String libPart = parts[0].replace("/", "-");
-                String numericPart = parts[1];
-                return baseUri + "#rules-" + libPart + "-" + numericPart;
-            }
-        } else {
-            // Core rule format: ballerina:numericId -> #rules-ballerina-numericId
-            if (parts.length == 2) {
-                String corePart = parts[0];
-                String numericPart = parts[1];
-                return baseUri + "#rules-" + corePart + "-" + numericPart;
-            }
-        }
-
-        // Fallback to original format if parsing fails
-        return baseUri + numericId;
+        String anchor;
+        String idPart = ruleId.replace(":", "").replace("/", "");
+        String descPart = description.toLowerCase(ROOT)
+                .replaceAll("[^a-z0-9]+", "-")
+                .replaceAll("-$", "")
+                .replaceAll("^-", "");
+        anchor = "#" + idPart + "---" + descPart;
+        return baseUri + anchor;
     }
 
     /**

--- a/scan-command/src/main/resources/cli-help/ballerina-scan.help
+++ b/scan-command/src/main/resources/cli-help/ballerina-scan.help
@@ -20,6 +20,9 @@ OPTIONS
         --scan-report
                 Generate an HTML report containing the analysis results (only for Ballerina projects).
 
+        --format=<json|sarif>
+                Specify the format of the report. Default is json.
+
         --list-rules
                 List all available rules.
 
@@ -46,6 +49,12 @@ EXAMPLES
 
         Run analysis and generate an HTML report in the target directory.
                 $ bal scan --scan-report
+
+        Run analysis and generate report in JSON format (default).
+                $ bal scan --format=json
+
+        Run analysis and generate report in SARIF format.
+                $ bal scan --format=sarif
 
         View all available rules.
                 $ bal scan --list-rules

--- a/scan-command/src/main/resources/scan.properties
+++ b/scan-command/src/main/resources/scan.properties
@@ -71,6 +71,9 @@ error.rule.not.found=\
 error.attempt.to.include.and.exclude=\
   cannot include and exclude rules at the same time
 
+error.invalid.format=\
+  invalid format ''{0}''. Supported formats are: json, sarif
+
 # --------------------------
 # Scan Tool warning messages
 # --------------------------

--- a/scan-command/src/test/java/io/ballerina/scan/internal/ScanCmdTest.java
+++ b/scan-command/src/test/java/io/ballerina/scan/internal/ScanCmdTest.java
@@ -50,7 +50,6 @@ import static io.ballerina.scan.TestConstants.WINDOWS_LINE_SEPARATOR;
 import static io.ballerina.scan.internal.ScanToolConstants.BALLERINAX_ORG;
 import static io.ballerina.scan.internal.ScanToolConstants.BALLERINA_ORG;
 import static io.ballerina.scan.utils.DiagnosticCode.EMPTY_PACKAGE;
-import static io.ballerina.scan.utils.DiagnosticCode.INVALID_FORMAT;
 import static io.ballerina.scan.utils.DiagnosticLog.error;
 
 /**
@@ -533,17 +532,19 @@ public class ScanCmdTest extends BaseTest {
     }
 
     @Test(description = "test scan command with invalid format flag")
-    void testScanCommandWithInvalidFormatFlag() throws IOException {
+    void testScanCommandWithInvalidFormatFlag() {
         System.setProperty("user.dir", validBalProject.toString());
         ScanCmd scanCmd = new ScanCmd(printStream);
         String[] args = {"--format=xml"};
-        new CommandLine(scanCmd).parseArgs(args);
-        scanCmd.execute();
-
+        try {
+            new CommandLine(scanCmd).parseArgs(args);
+            Assert.fail("Expected ParameterException to be thrown for invalid format");
+        } catch (CommandLine.ParameterException e) {
+            Assert.assertTrue(e.getMessage().contains("xml"), "Error message should mention the invalid format");
+            Assert.assertTrue(e.getMessage().contains("Unknown report format"),
+                    "Error message should indicate unknown format");
+        }
         System.setProperty("user.dir", userDir);
-        String output = readOutput(true).trim();
-        Assert.assertTrue(output.contains(error(INVALID_FORMAT, "xml")), "Should show invalid format error");
-        Assert.assertTrue(output.contains("xml"), "Error message should mention the invalid format");
     }
 
     @Test(description = "test scan command with format flag case insensitive")

--- a/scan-command/src/test/java/io/ballerina/scan/internal/ScanCmdTest.java
+++ b/scan-command/src/test/java/io/ballerina/scan/internal/ScanCmdTest.java
@@ -505,7 +505,7 @@ public class ScanCmdTest extends BaseTest {
     void testScanCommandWithValidJsonFormatFlag() throws IOException {
         System.setProperty("user.dir", validBalProject.toString());
         ScanCmd scanCmd = new ScanCmd(printStream);
-        String[] args = {"--format=json"};
+        String[] args = {"--format=ballerina"};
         new CommandLine(scanCmd).parseArgs(args);
         scanCmd.execute();
 
@@ -551,7 +551,7 @@ public class ScanCmdTest extends BaseTest {
     void testScanCommandWithFormatFlagCaseInsensitive() throws IOException {
         System.setProperty("user.dir", validBalProject.toString());
         ScanCmd scanCmd = new ScanCmd(printStream);
-        String[] args = {"--format=JSON"};
+        String[] args = {"--format=BALLERINA"};
         new CommandLine(scanCmd).parseArgs(args);
         scanCmd.execute();
 

--- a/scan-command/src/test/java/io/ballerina/scan/internal/ScanCmdTest.java
+++ b/scan-command/src/test/java/io/ballerina/scan/internal/ScanCmdTest.java
@@ -27,8 +27,6 @@ import io.ballerina.scan.Issue;
 import io.ballerina.scan.Rule;
 import io.ballerina.scan.RuleKind;
 import io.ballerina.scan.Source;
-import io.ballerina.scan.utils.DiagnosticCode;
-import io.ballerina.scan.utils.DiagnosticLog;
 import io.ballerina.scan.utils.ScanTomlFile;
 import io.ballerina.scan.utils.ScanUtils;
 import org.testng.Assert;
@@ -51,6 +49,9 @@ import static io.ballerina.scan.TestConstants.LINUX_LINE_SEPARATOR;
 import static io.ballerina.scan.TestConstants.WINDOWS_LINE_SEPARATOR;
 import static io.ballerina.scan.internal.ScanToolConstants.BALLERINAX_ORG;
 import static io.ballerina.scan.internal.ScanToolConstants.BALLERINA_ORG;
+import static io.ballerina.scan.utils.DiagnosticCode.EMPTY_PACKAGE;
+import static io.ballerina.scan.utils.DiagnosticCode.INVALID_FORMAT;
+import static io.ballerina.scan.utils.DiagnosticLog.error;
 
 /**
  * Scan command tests.
@@ -120,7 +121,7 @@ public class ScanCmdTest extends BaseTest {
         ScanCmd scanCmd = new ScanCmd(printStream);
         scanCmd.execute();
         System.setProperty("user.dir", userDir);
-        String expected = DiagnosticLog.error(DiagnosticCode.EMPTY_PACKAGE);
+        String expected = error(EMPTY_PACKAGE);
         Assert.assertEquals(readOutput(true).trim().split("\n")[0], expected);
     }
 
@@ -499,5 +500,100 @@ public class ScanCmdTest extends BaseTest {
         System.setProperty("user.dir", userDir);
         String expected = getExpectedOutput("invalid-platform-plugin-configurations.txt");
         Assert.assertEquals(readOutput(true).trim(), expected);
+    }
+
+    @Test(description = "test scan command with valid json format flag")
+    void testScanCommandWithValidJsonFormatFlag() throws IOException {
+        System.setProperty("user.dir", validBalProject.toString());
+        ScanCmd scanCmd = new ScanCmd(printStream);
+        String[] args = {"--format=json"};
+        new CommandLine(scanCmd).parseArgs(args);
+        scanCmd.execute();
+
+        System.setProperty("user.dir", userDir);
+        String expected = "Running Scans";
+        Assert.assertEquals(readOutput(true).trim().split("\n")[0], expected);
+        Path jsonReport = validBalProject.resolve("target").resolve("report").resolve("scan_results.json");
+        Assert.assertTrue(Files.exists(jsonReport), "JSON report file should be created");
+    }
+
+    @Test(description = "test scan command with valid sarif format flag")
+    void testScanCommandWithValidSarifFormatFlag() throws IOException {
+        System.setProperty("user.dir", validBalProject.toString());
+        ScanCmd scanCmd = new ScanCmd(printStream);
+        String[] args = {"--format=sarif"};
+        new CommandLine(scanCmd).parseArgs(args);
+        scanCmd.execute();
+
+        System.setProperty("user.dir", userDir);
+        String expected = "Running Scans";
+        Assert.assertEquals(readOutput(true).trim().split("\n")[0], expected);
+        Path sarifReport = validBalProject.resolve("target").resolve("report").resolve("scan_results.sarif");
+        Assert.assertTrue(Files.exists(sarifReport), "SARIF report file should be created");
+    }
+
+    @Test(description = "test scan command with invalid format flag")
+    void testScanCommandWithInvalidFormatFlag() throws IOException {
+        System.setProperty("user.dir", validBalProject.toString());
+        ScanCmd scanCmd = new ScanCmd(printStream);
+        String[] args = {"--format=xml"};
+        new CommandLine(scanCmd).parseArgs(args);
+        scanCmd.execute();
+
+        System.setProperty("user.dir", userDir);
+        String output = readOutput(true).trim();
+        Assert.assertTrue(output.contains(error(INVALID_FORMAT, "xml")), "Should show invalid format error");
+        Assert.assertTrue(output.contains("xml"), "Error message should mention the invalid format");
+    }
+
+    @Test(description = "test scan command with format flag case insensitive")
+    void testScanCommandWithFormatFlagCaseInsensitive() throws IOException {
+        System.setProperty("user.dir", validBalProject.toString());
+        ScanCmd scanCmd = new ScanCmd(printStream);
+        String[] args = {"--format=JSON"};
+        new CommandLine(scanCmd).parseArgs(args);
+        scanCmd.execute();
+
+        System.setProperty("user.dir", userDir);
+        String expected = "Running Scans";
+        Assert.assertEquals(readOutput(true).trim().split("\n")[0], expected);
+        System.setProperty("user.dir", validBalProject.toString());
+        scanCmd = new ScanCmd(printStream);
+        String[] sarifArgs = {"--format=SARIF"};
+        new CommandLine(scanCmd).parseArgs(sarifArgs);
+        scanCmd.execute();
+        System.setProperty("user.dir", userDir);
+        expected = "Running Scans";
+        Assert.assertEquals(readOutput(true).trim().split("\n")[0], expected);
+    }
+
+    @Test(description = "test scan command with format flag combined with target-dir")
+    void testScanCommandWithFormatFlagAndTargetDir() throws IOException {
+        System.setProperty("user.dir", validBalProject.toString());
+        ScanCmd scanCmd = new ScanCmd(printStream);
+        String[] args = {"--format=sarif", "--target-dir=custom-results"};
+        new CommandLine(scanCmd).parseArgs(args);
+        scanCmd.execute();
+
+        System.setProperty("user.dir", userDir);
+        String expected = "Running Scans";
+        Assert.assertEquals(readOutput(true).trim().split("\n")[0], expected);
+        Path sarifReport = validBalProject.resolve("custom-results").resolve("report")
+                .resolve("scan_results.sarif");
+        Assert.assertTrue(Files.exists(sarifReport), "SARIF report file should be created in custom directory");
+        removeFile(validBalProject.resolve("custom-results"));
+    }
+
+    @Test(description = "test scan command default format behavior")
+    void testScanCommandDefaultFormatBehavior() throws IOException {
+        System.setProperty("user.dir", validBalProject.toString());
+        ScanCmd scanCmd = new ScanCmd(printStream);
+        scanCmd.execute();
+
+        System.setProperty("user.dir", userDir);
+        String expected = "Running Scans";
+        Assert.assertEquals(readOutput(true).trim().split("\n")[0], expected);
+        Path jsonReport = validBalProject.resolve("target").resolve("report").resolve("scan_results.json");
+        Assert.assertTrue(Files.exists(jsonReport), "JSON report file should be created by default");
     }
 }

--- a/scan-command/src/test/resources/command-outputs/common/tool-help.txt
+++ b/scan-command/src/test/resources/command-outputs/common/tool-help.txt
@@ -20,6 +20,9 @@ OPTIONS
         --scan-report
                 Generate an HTML report containing the analysis results (only for Ballerina projects).
 
+        --format=<json|sarif>
+                Specify the format of the report. Default is json.
+
         --list-rules
                 List all available rules.
 
@@ -46,6 +49,12 @@ EXAMPLES
 
         Run analysis and generate an HTML report in the target directory.
                 $ bal scan --scan-report
+
+        Run analysis and generate report in JSON format (default).
+                $ bal scan --format=json
+
+        Run analysis and generate report in SARIF format.
+                $ bal scan --format=sarif
 
         View all available rules.
                 $ bal scan --list-rules

--- a/scan-command/tool-scan/BalTool.toml
+++ b/scan-command/tool-scan/BalTool.toml
@@ -2,4 +2,4 @@
 id = "scan"
 
 [[dependency]]
-path = "../build/libs/scan-command-0.10.0.jar"
+path = "../build/libs/scan-command-0.10.1-SNAPSHOT.jar"

--- a/scan-command/tool-scan/BalTool.toml
+++ b/scan-command/tool-scan/BalTool.toml
@@ -2,4 +2,4 @@
 id = "scan"
 
 [[dependency]]
-path = "../build/libs/scan-command-0.10.1-SNAPSHOT.jar"
+path = "../build/libs/scan-command-0.11.0-SNAPSHOT.jar"

--- a/scan-command/tool-scan/Ballerina.toml
+++ b/scan-command/tool-scan/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "tool_scan"
-version = "0.10.0"
+version = "0.10.1-SNAPSHOT"
 distribution = "2201.12.0"
 authors = ["Ballerina"]
 keywords = ["scan", "static code analysis"]

--- a/scan-command/tool-scan/Ballerina.toml
+++ b/scan-command/tool-scan/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "tool_scan"
-version = "0.10.1-SNAPSHOT"
+version = "0.11.0-SNAPSHOT"
 distribution = "2201.12.0"
 authors = ["Ballerina"]
 keywords = ["scan", "static code analysis"]

--- a/scan-command/tool-scan/Dependencies.toml
+++ b/scan-command/tool-scan/Dependencies.toml
@@ -5,12 +5,12 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.0"
+distribution-version = "2201.12.7"
 
 [[package]]
 org = "ballerina"
 name = "tool_scan"
-version = "0.10.0"
+version = "0.10.1-SNAPSHOT"
 modules = [
 	{org = "ballerina", packageName = "tool_scan", moduleName = "tool_scan"}
 ]

--- a/scan-command/tool-scan/Dependencies.toml
+++ b/scan-command/tool-scan/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.12.7"
 [[package]]
 org = "ballerina"
 name = "tool_scan"
-version = "0.10.1-SNAPSHOT"
+version = "0.11.0-SNAPSHOT"
 modules = [
 	{org = "ballerina", packageName = "tool_scan", moduleName = "tool_scan"}
 ]

--- a/scan-command/tool-scan/README.md
+++ b/scan-command/tool-scan/README.md
@@ -25,10 +25,10 @@ bal scan [OPTIONS] [<package>|<source-file>]
 --scan-report
 ```
 
-- Specify the output format (json or sarif). Default is json.
+- Specify the output format (ballerina or sarif). Default is ballerina.
 
 ```text
---format=<json|sarif>
+--format=<ballerina|sarif>
 ```
 
 -  List all available rules

--- a/scan-command/tool-scan/README.md
+++ b/scan-command/tool-scan/README.md
@@ -25,6 +25,12 @@ bal scan [OPTIONS] [<package>|<source-file>]
 --scan-report
 ```
 
+- Specify the output format (json or sarif). Default is json.
+
+```text
+--format=<json|sarif>
+```
+
 -  List all available rules
 
 ```text
@@ -73,6 +79,12 @@ bal scan --target-dir="results"
 
 ```bash
 bal scan --scan-report
+```
+
+- Run analysis and specify the output format as SARIF.
+
+```bash
+bal scan --format=sarif
 ```
 
 - View all available rules.


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/static-code-analysis-tool/issues/68

## Approach

This PR adds support for the Static Analysis Results Interchange Format (SARIF) in addition to the existing `JSON` output. The implementation preserves backward compatibility and introduces `SARIF` as an alternative reporting option for improved integration with external development tools.

A new `convertIssuesToSarifString` method has been implemented to generate `SARIF`-compliant output by mapping internal `Issue` objects to the `SARIF` schema, including sections such as `runs`, `driver`, `rules`, and `results`. Severity levels defined by `RuleKind` are translated to their `SARIF` equivalents using a helper method, and detailed source location data—including line and column positions—is included in the output.

The `Gson` library continues to be used for pretty-printing in both `JSON` and `SARIF` formats. Output format selection is handled via a new `--format` flag in the CLI, with input validation to restrict accepted values. Both console and file output workflows support the new format, with `JSON` remaining the default when no format is specified.

## Check List

- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Integration Tests