### PR TITLE
Move "running scans" output message earlier in the execution flow

### DIFF
--- a/scan-command/src/main/java/io/ballerina/scan/internal/ScanCmd.java
+++ b/scan-command/src/main/java/io/ballerina/scan/internal/ScanCmd.java
@@ -57,7 +57,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
 
-import static io.ballerina.scan.internal.ScanToolConstants.RUNNING_SCANS;
+import static io.ballerina.scan.internal.ScanToolConstants.RUNNING_SCANS_LOG;
 import static io.ballerina.scan.internal.ScanToolConstants.SCAN_COMMAND;
 
 /**
@@ -187,7 +187,7 @@ public class ScanCmd implements BLauncherCmd {
         }
 
         outputStream.println();
-        outputStream.println(RUNNING_SCANS);
+        outputStream.println(RUNNING_SCANS_LOG);
 
         ProjectAnalyzer projectAnalyzer = getProjectAnalyzer(project.get(), scanTomlFile.get());
         List<Rule> coreRules = CoreRule.rules();

--- a/scan-command/src/main/java/io/ballerina/scan/internal/ScanCmd.java
+++ b/scan-command/src/main/java/io/ballerina/scan/internal/ScanCmd.java
@@ -57,6 +57,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
 
+import static io.ballerina.scan.internal.ScanToolConstants.RUNNING_SCANS;
 import static io.ballerina.scan.internal.ScanToolConstants.SCAN_COMMAND;
 
 /**
@@ -186,7 +187,7 @@ public class ScanCmd implements BLauncherCmd {
         }
 
         outputStream.println();
-        outputStream.println("Running Scans");
+        outputStream.println(RUNNING_SCANS);
 
         ProjectAnalyzer projectAnalyzer = getProjectAnalyzer(project.get(), scanTomlFile.get());
         List<Rule> coreRules = CoreRule.rules();

--- a/scan-command/src/main/java/io/ballerina/scan/internal/ScanCmd.java
+++ b/scan-command/src/main/java/io/ballerina/scan/internal/ScanCmd.java
@@ -185,6 +185,9 @@ public class ScanCmd implements BLauncherCmd {
             return;
         }
 
+        outputStream.println();
+        outputStream.println("Running Scans");
+
         ProjectAnalyzer projectAnalyzer = getProjectAnalyzer(project.get(), scanTomlFile.get());
         List<Rule> coreRules = CoreRule.rules();
         Map<String, List<Rule>> externalAnalyzers;
@@ -232,9 +235,6 @@ public class ScanCmd implements BLauncherCmd {
             outputStream.println(DiagnosticLog.error(DiagnosticCode.ATTEMPT_TO_INCLUDE_AND_EXCLUDE));
             return;
         }
-
-        outputStream.println();
-        outputStream.println("Running Scans");
 
         List<Issue> issues = projectAnalyzer.analyze(coreRules);
         issues.addAll(projectAnalyzer.runExternalAnalyzers(externalAnalyzers));

--- a/scan-command/src/main/java/io/ballerina/scan/internal/ScanToolConstants.java
+++ b/scan-command/src/main/java/io/ballerina/scan/internal/ScanToolConstants.java
@@ -38,6 +38,7 @@ public class ScanToolConstants {
     static final String CODE_SMELL = "CODE_SMELL";
     static final String RULE_ID = "id";
     static final String RULE_DESCRIPTION = "description";
+    static final String RUNNING_SCANS = "Running Scans";
 
     public static final String SCANNER_CONTEXT = "ScannerContext";
     public static final String FORWARD_SLASH = "/";

--- a/scan-command/src/main/java/io/ballerina/scan/internal/ScanToolConstants.java
+++ b/scan-command/src/main/java/io/ballerina/scan/internal/ScanToolConstants.java
@@ -38,7 +38,7 @@ public class ScanToolConstants {
     static final String CODE_SMELL = "CODE_SMELL";
     static final String RULE_ID = "id";
     static final String RULE_DESCRIPTION = "description";
-    static final String RUNNING_SCANS = "Running Scans";
+    static final String RUNNING_SCANS_LOG = "Running Scans";
 
     public static final String SCANNER_CONTEXT = "ScannerContext";
     public static final String FORWARD_SLASH = "/";

--- a/scan-command/src/test/resources/command-outputs/unix/include-exclude-rules.txt
+++ b/scan-command/src/test/resources/command-outputs/unix/include-exclude-rules.txt
@@ -1,2 +1,4 @@
 Loading scan tool configurations from src/test/resources/test-resources/bal-project-with-analyzer-configurations/Scan.toml
+
+Running Scans
 cannot include and exclude rules at the same time

--- a/scan-command/src/test/resources/command-outputs/unix/list-rules-output.txt
+++ b/scan-command/src/test/resources/command-outputs/unix/list-rules-output.txt
@@ -1,4 +1,6 @@
 Loading scan tool configurations from src/test/resources/test-resources/bal-project-with-config-file/Scan.toml
+
+Running Scans
 	RuleID                                           | Rule Kind     | Rule Description                                 
 	---------------------------------------------------------------------------------------------------------------------
 	ballerina:1                                      | CODE_SMELL    | Avoid checkpanic

--- a/scan-command/src/test/resources/command-outputs/unix/toml-include-exclude-rules.txt
+++ b/scan-command/src/test/resources/command-outputs/unix/toml-include-exclude-rules.txt
@@ -1,2 +1,4 @@
 Loading scan tool configurations from src/test/resources/test-resources/bal-project-with-include-exclude-rule-configurations/Scan.toml
+
+Running Scans
 cannot include and exclude rules at the same time

--- a/scan-command/src/test/resources/command-outputs/windows/include-exclude-rules.txt
+++ b/scan-command/src/test/resources/command-outputs/windows/include-exclude-rules.txt
@@ -1,2 +1,4 @@
 Loading scan tool configurations from src\test\resources\test-resources\bal-project-with-analyzer-configurations\Scan.toml
+
+Running Scans
 cannot include and exclude rules at the same time

--- a/scan-command/src/test/resources/command-outputs/windows/list-rules-output.txt
+++ b/scan-command/src/test/resources/command-outputs/windows/list-rules-output.txt
@@ -1,4 +1,6 @@
 Loading scan tool configurations from src\test\resources\test-resources\bal-project-with-config-file\Scan.toml
+
+Running Scans
 	RuleID                                           | Rule Kind     | Rule Description                                 
 	---------------------------------------------------------------------------------------------------------------------
 	ballerina:1                                      | CODE_SMELL    | Avoid checkpanic

--- a/scan-command/src/test/resources/command-outputs/windows/toml-include-exclude-rules.txt
+++ b/scan-command/src/test/resources/command-outputs/windows/toml-include-exclude-rules.txt
@@ -1,2 +1,4 @@
 Loading scan tool configurations from src\test\resources\test-resources\bal-project-with-include-exclude-rule-configurations\Scan.toml
+
+Running Scans
 cannot include and exclude rules at the same time


### PR DESCRIPTION
## Purpose

Fixes: https://github.com/ballerina-platform/static-code-analysis-tool/issues/75

In the original implementation, it took a considerable amount of time for the 'Running scans' text to appear in the console, because several time-consuming operations were performed beforehand.

1. Loading project configurations
2. Getting external analyzers
3. Loading platform plugins
4. Processing rules to include/exclude

## Approach

This change moved the "Running Scans" message much earlier in the execution flow, right after the basic validation but before the heavy operations.

<img width="774" height="557" alt="image" src="https://github.com/user-attachments/assets/19ef6610-3406-4f1d-b2c8-92190bb4076b" />

## Check List

- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Integration Tests