### PR TITLE
Support scanning workspaces

### DIFF
--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set Up Ballerina
         uses: ballerina-platform/setup-ballerina@v1.1.0
         with:
-          version: 2201.13.0
+          version: 2201.13.2
 
       - name: Build with Gradle
         env:

--- a/.github/workflows/central-publish.yml
+++ b/.github/workflows/central-publish.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set Up Ballerina
         uses: ballerina-platform/setup-ballerina@v1.1.0
         with:
-          version: 2201.12.0
+          version: 2201.13.0
 
       - name: Build with Gradle
         env:

--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set Up Ballerina
         uses: ballerina-platform/setup-ballerina@v1.1.1
         with:
-          version: 2201.12.0
+          version: 2201.13.0
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -35,7 +35,7 @@ jobs:
         env:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew build --scan
+        run: unset BALLERINA_HOME && ./gradlew build --scan
 
       - name: Generate Jacoco report
         run: ./gradlew createCodeCoverageReport
@@ -66,10 +66,10 @@ jobs:
       - name: Set Up Ballerina
         uses: ballerina-platform/setup-ballerina@v1.1.1
         with:
-          version: 2201.12.0
+          version: 2201.13.0
 
       - name: Build with Gradle
         env:
           packageUser: ${{ github.actor }}
           packagePAT: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew build --scan
+        run: Remove-Item Env:BALLERINA_HOME -ErrorAction SilentlyContinue;  ./gradlew build --scan

--- a/.github/workflows/full_build.yml
+++ b/.github/workflows/full_build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set Up Ballerina
         uses: ballerina-platform/setup-ballerina@v1.1.1
         with:
-          version: 2201.13.0
+          version: 2201.13.2
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -66,7 +66,7 @@ jobs:
       - name: Set Up Ballerina
         uses: ballerina-platform/setup-ballerina@v1.1.1
         with:
-          version: 2201.13.0
+          version: 2201.13.2
 
       - name: Build with Gradle
         env:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set Up Ballerina
         uses: ballerina-platform/setup-ballerina@v1.1.0
         with:
-          version: 2201.12.0
+          version: 2201.13.0
 
       - name: Set version env variable
         run: echo "VERSION=$((grep -w "version" | cut -d= -f2) < gradle.properties | rev | cut --complement -d- -f1 | rev)" >> $GITHUB_ENV

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set Up Ballerina
         uses: ballerina-platform/setup-ballerina@v1.1.0
         with:
-          version: 2201.13.0
+          version: 2201.13.2
 
       - name: Set version env variable
         run: echo "VERSION=$((grep -w "version" | cut -d= -f2) < gradle.properties | rev | cut --complement -d- -f1 | rev)" >> $GITHUB_ENV

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ enterprisePluginVersion=3.18.1
 # Dependency versions
 picoCLIVersion=4.7.5
 gsonVersion=2.10.1
-ballerinaLangVersion=2201.12.0
+ballerinaLangVersion=2201.13.0
 puppycrawlCheckstyleVersion=10.12.1
 apacheCommonsLang3Version=3.0
 commonsIoVersion=2.15.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ enterprisePluginVersion=3.18.1
 # Dependency versions
 picoCLIVersion=4.7.5
 gsonVersion=2.10.1
-ballerinaLangVersion=2201.13.0
+ballerinaLangVersion=2201.13.2
 puppycrawlCheckstyleVersion=10.12.1
 apacheCommonsLang3Version=3.0
 commonsIoVersion=2.15.1

--- a/scan-command-test-utils/src/main/java/io/ballerina/scan/test/TestScanCmd.java
+++ b/scan-command-test-utils/src/main/java/io/ballerina/scan/test/TestScanCmd.java
@@ -20,8 +20,7 @@ package io.ballerina.scan.test;
 
 import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectEnvironmentBuilder;
-import io.ballerina.projects.directory.BuildProject;
-import io.ballerina.projects.directory.SingleFileProject;
+import io.ballerina.projects.directory.ProjectLoader;
 import io.ballerina.projects.environment.Environment;
 import io.ballerina.projects.environment.EnvironmentBuilder;
 import io.ballerina.scan.internal.ProjectAnalyzer;
@@ -72,11 +71,7 @@ public class TestScanCmd extends ScanCmd {
                 Collections.emptyList(),
                 Collections.emptyList(),
                 Collections.emptyList());
-        if (projectPath.toFile().isDirectory()) {
-            project = BuildProject.load(getEnvironmentBuilder(distributionPath), projectPath);
-        } else {
-            project = SingleFileProject.load(getEnvironmentBuilder(distributionPath), projectPath);
-        }
+        project = ProjectLoader.load(projectPath, getEnvironmentBuilder(distributionPath)).project();
     }
 
     @Override

--- a/scan-command/build.gradle
+++ b/scan-command/build.gradle
@@ -279,8 +279,22 @@ build {
 
 // Configuring tests
 tasks.test {
-    systemProperty "ballerina.home", Paths.get(System.getenv("BALLERINA_HOME")).resolve("distributions")
-            .resolve("ballerina-${ballerinaLangVersion}").toString()
+    // set ballerina home is env var is set
+    def ballerinaHome = System.getenv("BALLERINA_HOME")
+    if (ballerinaHome != null) {
+        systemProperty 'ballerina.home', ballerinaHome
+    } else {
+        try {
+            def balHomeOutput = new ByteArrayOutputStream()
+            exec {
+                commandLine 'bal', 'home'
+                standardOutput = balHomeOutput
+            }
+            systemProperty 'ballerina.home', balHomeOutput.toString().trim()
+        } catch (Exception e) {
+            println "Warning: Could not determine ballerina.home from 'bal home' command: ${e.message}"
+        }
+    }
 
     useTestNG() {
         suites 'src/test/resources/testng.xml'

--- a/scan-command/build.gradle
+++ b/scan-command/build.gradle
@@ -279,21 +279,23 @@ build {
 
 // Configuring tests
 tasks.test {
-    // set ballerina home is env var is set
-    def ballerinaHome = System.getenv("BALLERINA_HOME")
-    if (ballerinaHome != null) {
-        systemProperty "ballerina.home",  Paths.get(ballerinaHome).resolve("distributions").toString()
-    } else {
-        try {
-            def balHomeOutput = new ByteArrayOutputStream()
-            exec {
-                commandLine 'bal', 'home'
-                standardOutput = balHomeOutput
+    // set ballerina home system property for java based tests
+    def balHomeOutput = ""
+    try {
+        balHomeOutput = new ByteArrayOutputStream()
+        exec {
+            if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+                // Use cmd so Windows can run the .bat reliably
+                commandLine 'cmd', '/c', 'bal.bat home'
+            } else {
+                commandLine 'sh', '-c', 'bal home'
             }
-            systemProperty 'ballerina.home', balHomeOutput.toString().trim()
-        } catch (Exception e) {
-            println "Warning: Could not determine ballerina.home from 'bal home' command: ${e.message}"
+            standardOutput = balHomeOutput
         }
+        systemProperty 'ballerina.home', balHomeOutput.toString().trim()
+    } catch (Exception e) {
+        println "Warning: Could not determine ballerina.home from 'bal home' command: ${e.message}" +
+                "\nOutput: " + balHomeOutput
     }
 
     useTestNG() {

--- a/scan-command/build.gradle
+++ b/scan-command/build.gradle
@@ -282,7 +282,7 @@ tasks.test {
     // set ballerina home is env var is set
     def ballerinaHome = System.getenv("BALLERINA_HOME")
     if (ballerinaHome != null) {
-        systemProperty 'ballerina.home', ballerinaHome
+        systemProperty "ballerina.home",  Paths.get(ballerinaHome).resolve("distributions").toString()
     } else {
         try {
             def balHomeOutput = new ByteArrayOutputStream()

--- a/scan-command/build.gradle
+++ b/scan-command/build.gradle
@@ -296,6 +296,15 @@ tasks.test {
     } catch (Exception e) {
         println "Warning: Could not determine ballerina.home from 'bal home' command: ${e.message}" +
                 "\nOutput: " + balHomeOutput
+        def ballerinaHomeEnv = System.getenv("BALLERINA_HOME")
+        if (ballerinaHomeEnv) {
+            systemProperty 'ballerina.home', ballerinaHomeEnv.trim()
+        } else {
+            throw new GradleException(
+                "'bal home' failed and BALLERINA_HOME is not set — tests cannot run. " +
+                "Output: ${balHomeOutput}"
+            )
+        }
     }
 
     useTestNG() {

--- a/scan-command/src/main/java/io/ballerina/scan/internal/ReporterImpl.java
+++ b/scan-command/src/main/java/io/ballerina/scan/internal/ReporterImpl.java
@@ -29,6 +29,7 @@ import io.ballerina.scan.utils.DiagnosticLog;
 import io.ballerina.scan.utils.ScanToolException;
 import io.ballerina.tools.diagnostics.Location;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -90,8 +91,9 @@ public class ReporterImpl implements Reporter {
                 source = Source.EXTERNAL;
             }
         }
-        return new IssueImpl(location, rule, source, moduleName + FORWARD_SLASH + documentName,
-                issuesFilePath.toString());
+        boolean isWorkspaceSubProject = module.project().workspaceProject().isPresent();
+        String fileName = isWorkspaceSubProject ? moduleName + File.separator + documentName : documentName;
+        return new IssueImpl(location, rule, source, fileName, issuesFilePath.toString());
     }
 
     protected List<Issue> getIssues() {

--- a/scan-command/src/main/java/io/ballerina/scan/internal/ScanCmd.java
+++ b/scan-command/src/main/java/io/ballerina/scan/internal/ScanCmd.java
@@ -18,9 +18,6 @@
 
 package io.ballerina.scan.internal;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
 import io.ballerina.cli.BLauncherCmd;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectKind;
@@ -67,6 +64,8 @@ import java.util.ServiceLoader;
 
 import static io.ballerina.scan.internal.ScanToolConstants.RUNNING_SCANS_LOG;
 import static io.ballerina.scan.internal.ScanToolConstants.SCAN_COMMAND;
+import static io.ballerina.scan.utils.ScanUtils.convertIssuesToJsonString;
+import static io.ballerina.scan.utils.ScanUtils.convertIssuesToSarifString;
 
 /**
  * Represents the "bal scan" command.
@@ -202,19 +201,7 @@ public class ScanCmd implements BLauncherCmd {
             }
 
             outputStream.println();
-            Path jsonReportPath;
-            try {
-                String reportContent = accumulateWorkspaceReports(topologicallySortedList);
-                jsonReportPath = ScanUtils.getTargetPath(project.get(), targetDir).getReportPath()
-                        .resolve(Constants.RESULTS_JSON_FILE);
-                Files.writeString(jsonReportPath, reportContent);
-            } catch (IOException e) {
-                throw new RuntimeException("Error while obtaining report path: " + e.getMessage());
-            }
-
-            outputStream.println("View scan results at:");
-            outputStream.println("\t" + jsonReportPath.toUri());
-            outputStream.println();
+            accumulateWorkspaceReports(workspaceProject);
             if (scanReport) {
                 Path scanReportPath = ScanUtils.generateScanReport(allIssues, project.get(), targetDir);
                 outputStream.println();
@@ -231,27 +218,26 @@ public class ScanCmd implements BLauncherCmd {
         executeProject(project.get());
     }
 
-    private String accumulateWorkspaceReports(List<BuildProject> topologicallySortedList) {
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        JsonArray allIssuesArray = new JsonArray();
-
-        for (BuildProject buildProject : topologicallySortedList) {
-            try {
-                Path reportPath = ScanUtils.getTargetPath(buildProject, targetDir).getReportPath()
+    private void accumulateWorkspaceReports(WorkspaceProject workspaceProject) {
+        try {
+            Path finalReportPath;
+            String finalReportContent;
+            if (ReportFormat.SARIF.equals(format)) {
+                finalReportPath = ScanUtils.getTargetPath(workspaceProject, targetDir).getReportPath()
+                        .resolve(Constants.RESULTS_SARIF_FILE);
+                finalReportContent = convertIssuesToSarifString(allIssues, workspaceProject);
+            } else {
+                finalReportPath = ScanUtils.getTargetPath(workspaceProject, targetDir).getReportPath()
                         .resolve(Constants.RESULTS_JSON_FILE);
-                if (Files.exists(reportPath)) {
-                    String content = Files.readString(reportPath, StandardCharsets.UTF_8);
-                    JsonArray issuesArray = gson.fromJson(content, JsonArray.class);
-                    if (issuesArray != null) {
-                        issuesArray.forEach(allIssuesArray::add);
-                    }
-                }
-            } catch (IOException e) {
-                throw new RuntimeException("Error while obtaining report path: " + e.getMessage());
+                finalReportContent = convertIssuesToJsonString(allIssues);
             }
+            Files.writeString(finalReportPath, finalReportContent);
+            outputStream.println("View scan results at:");
+            outputStream.println("\t" + finalReportPath.toUri());
+            outputStream.println();
+        } catch (IOException e) {
+            throw new RuntimeException("Error while obtaining report path: " + e.getMessage());
         }
-
-        return gson.toJson(allIssues);
     }
 
     public void executeProject(Project project) {

--- a/scan-command/src/main/java/io/ballerina/scan/internal/ScanCmd.java
+++ b/scan-command/src/main/java/io/ballerina/scan/internal/ScanCmd.java
@@ -199,7 +199,9 @@ public class ScanCmd implements BLauncherCmd {
                 }
                 executeProject(buildProject);
             }
-
+            if (listRules) {
+                return;
+            }
             outputStream.println();
             accumulateWorkspaceReports(workspaceProject);
             if (scanReport) {
@@ -236,7 +238,7 @@ public class ScanCmd implements BLauncherCmd {
             outputStream.println("\t" + finalReportPath.toUri());
             outputStream.println();
         } catch (IOException e) {
-            throw new RuntimeException("Error while obtaining report path: " + e.getMessage());
+            throw new RuntimeException("Error while obtaining report path: " + e.getMessage(), e);
         }
     }
 
@@ -290,9 +292,13 @@ public class ScanCmd implements BLauncherCmd {
             }
         });
 
-        scanTomlFile.get().getRulesToInclude().stream().map(ScanTomlFile.RuleToFilter::id).forEach(includeRules::add);
-        scanTomlFile.get().getRulesToExclude().stream().map(ScanTomlFile.RuleToFilter::id).forEach(excludeRules::add);
-        if (!includeRules.isEmpty() && !excludeRules.isEmpty()) {
+        List<String> projectIncludeRules = new ArrayList<>(includeRules);
+        List<String> projectExcludeRules = new ArrayList<>(excludeRules);
+        scanTomlFile.get().getRulesToInclude().stream().map(ScanTomlFile.RuleToFilter::id)
+                .forEach(projectIncludeRules::add);
+        scanTomlFile.get().getRulesToExclude().stream().map(ScanTomlFile.RuleToFilter::id)
+                .forEach(projectExcludeRules::add);
+        if (!projectIncludeRules.isEmpty() && !projectExcludeRules.isEmpty()) {
             outputStream.println(DiagnosticLog.error(DiagnosticCode.ATTEMPT_TO_INCLUDE_AND_EXCLUDE));
             return;
         }
@@ -300,11 +306,11 @@ public class ScanCmd implements BLauncherCmd {
         List<Issue> issues = projectAnalyzer.analyze(coreRules);
         issues.addAll(projectAnalyzer.runExternalAnalyzers(externalAnalyzers));
 
-        if (!includeRules.isEmpty()) {
-            issues.removeIf(issue -> !includeRules.contains(issue.rule().id()));
+        if (!projectIncludeRules.isEmpty()) {
+            issues.removeIf(issue -> !projectIncludeRules.contains(issue.rule().id()));
         }
-        if (!excludeRules.isEmpty()) {
-            issues.removeIf(issue -> excludeRules.contains(issue.rule().id()));
+        if (!projectExcludeRules.isEmpty()) {
+            issues.removeIf(issue -> projectExcludeRules.contains(issue.rule().id()));
         }
 
         allIssues.addAll(issues);

--- a/scan-command/src/main/java/io/ballerina/scan/internal/ScanCmd.java
+++ b/scan-command/src/main/java/io/ballerina/scan/internal/ScanCmd.java
@@ -18,18 +18,25 @@
 
 package io.ballerina.scan.internal;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
 import io.ballerina.cli.BLauncherCmd;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectKind;
+import io.ballerina.projects.ProjectLoadResult;
 import io.ballerina.projects.directory.BuildProject;
-import io.ballerina.projects.directory.SingleFileProject;
+import io.ballerina.projects.directory.ProjectLoader;
+import io.ballerina.projects.directory.WorkspaceProject;
 import io.ballerina.projects.util.ProjectConstants;
+import io.ballerina.projects.util.ProjectPaths;
 import io.ballerina.projects.util.ProjectUtils;
 import io.ballerina.scan.Issue;
 import io.ballerina.scan.PlatformPluginContext;
 import io.ballerina.scan.ReportFormat;
 import io.ballerina.scan.Rule;
 import io.ballerina.scan.StaticCodeAnalysisPlatformPlugin;
+import io.ballerina.scan.utils.Constants;
 import io.ballerina.scan.utils.DiagnosticCode;
 import io.ballerina.scan.utils.DiagnosticLog;
 import io.ballerina.scan.utils.ScanTomlFile;
@@ -46,6 +53,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -107,6 +115,7 @@ public class ScanCmd implements BLauncherCmd {
     private List<String> platforms = new ArrayList<>();
 
     private final List<Rule> allRules = new ArrayList<>();
+    private final List<Issue> allIssues;
 
     public ScanCmd() {
         this(System.out);
@@ -115,6 +124,7 @@ public class ScanCmd implements BLauncherCmd {
     ScanCmd(PrintStream outputStream) {
         this.projectPath = Paths.get(System.getProperty(ProjectConstants.USER_DIR));
         this.outputStream = outputStream;
+        this.allIssues = new ArrayList<>();
     }
 
     protected ScanCmd(
@@ -140,6 +150,7 @@ public class ScanCmd implements BLauncherCmd {
         this.includeRules.addAll(includeRules.stream().map(Rule::id).toList());
         this.excludeRules.addAll(excludeRules.stream().map(Rule::id).toList());
         this.platforms.addAll(platforms);
+        this.allIssues = new ArrayList<>();
     }
 
     @Override
@@ -176,12 +187,75 @@ public class ScanCmd implements BLauncherCmd {
             return;
         }
 
+        if (project.get().kind() == ProjectKind.WORKSPACE_PROJECT) {
+            outputStream.println();
+            outputStream.println("Resolving workspace dependencies");
+            WorkspaceProject workspaceProject = (WorkspaceProject) project.get();
+            List<BuildProject> topologicallySortedList =
+                    workspaceProject.getResolution().dependencyGraph().toTopologicallySortedList();
+            for (BuildProject buildProject : topologicallySortedList) {
+                if (ProjectUtils.isProjectEmpty(buildProject)) {
+                    outputStream.println(DiagnosticLog.error(DiagnosticCode.EMPTY_PACKAGE));
+                    continue;
+                }
+                executeProject(buildProject);
+            }
+
+            outputStream.println();
+            Path jsonReportPath;
+            try {
+                String reportContent = accumulateWorkspaceReports(topologicallySortedList);
+                jsonReportPath = ScanUtils.getTargetPath(project.get(), targetDir).getReportPath()
+                        .resolve(Constants.RESULTS_JSON_FILE);
+                Files.writeString(jsonReportPath, reportContent);
+            } catch (IOException e) {
+                throw new RuntimeException("Error while obtaining report path: " + e.getMessage());
+            }
+
+            outputStream.println("View scan results at:");
+            outputStream.println("\t" + jsonReportPath.toUri());
+            outputStream.println();
+            if (scanReport) {
+                Path scanReportPath = ScanUtils.generateScanReport(allIssues, project.get(), targetDir);
+                outputStream.println();
+                outputStream.println("View scan report at:");
+                outputStream.println("\t" + scanReportPath.toUri() + System.lineSeparator());
+            }
+
+            return;
+        }
         if (ProjectUtils.isProjectEmpty(project.get())) {
             outputStream.println(DiagnosticLog.error(DiagnosticCode.EMPTY_PACKAGE));
             return;
         }
+        executeProject(project.get());
+    }
 
-        Optional<ScanTomlFile> scanTomlFile = ScanUtils.loadScanTomlConfigurations(project.get(), outputStream);
+    private String accumulateWorkspaceReports(List<BuildProject> topologicallySortedList) {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        JsonArray allIssuesArray = new JsonArray();
+
+        for (BuildProject buildProject : topologicallySortedList) {
+            try {
+                Path reportPath = ScanUtils.getTargetPath(buildProject, targetDir).getReportPath()
+                        .resolve(Constants.RESULTS_JSON_FILE);
+                if (Files.exists(reportPath)) {
+                    String content = Files.readString(reportPath, StandardCharsets.UTF_8);
+                    JsonArray issuesArray = gson.fromJson(content, JsonArray.class);
+                    if (issuesArray != null) {
+                        issuesArray.forEach(allIssuesArray::add);
+                    }
+                }
+            } catch (IOException e) {
+                throw new RuntimeException("Error while obtaining report path: " + e.getMessage());
+            }
+        }
+
+        return gson.toJson(allIssues);
+    }
+
+    public void executeProject(Project project) {
+        Optional<ScanTomlFile> scanTomlFile = ScanUtils.loadScanTomlConfigurations(project, outputStream);
         if (scanTomlFile.isEmpty()) {
             return;
         }
@@ -189,7 +263,7 @@ public class ScanCmd implements BLauncherCmd {
         outputStream.println();
         outputStream.println(RUNNING_SCANS_LOG);
 
-        ProjectAnalyzer projectAnalyzer = getProjectAnalyzer(project.get(), scanTomlFile.get());
+        ProjectAnalyzer projectAnalyzer = getProjectAnalyzer(project, scanTomlFile.get());
         List<Rule> coreRules = CoreRule.rules();
         Map<String, List<Rule>> externalAnalyzers;
         try {
@@ -247,25 +321,30 @@ public class ScanCmd implements BLauncherCmd {
             issues.removeIf(issue -> excludeRules.contains(issue.rule().id()));
         }
 
+        allIssues.addAll(issues);
+
         if (platforms.isEmpty() && !platformTriggered) {
             boolean isSarifFormat = ReportFormat.SARIF.equals(format);
-            ScanUtils.printToConsole(issues, outputStream, isSarifFormat, project.get());
-            if (project.get().kind().equals(ProjectKind.BUILD_PROJECT)) {
+            ScanUtils.printToConsole(issues, outputStream, isSarifFormat, project);
+            if (project.kind().equals(ProjectKind.BUILD_PROJECT)) {
                 Path reportPath;
                 if (isSarifFormat) {
-                    reportPath = ScanUtils.saveSarifToDirectory(issues, project.get(), targetDir);
+                    reportPath = ScanUtils.saveSarifToDirectory(issues, project, targetDir);
                 } else {
-                    reportPath = ScanUtils.saveToDirectory(issues, project.get(), targetDir);
+                    reportPath = ScanUtils.saveToDirectory(issues, project, targetDir);
                 }
-                outputStream.println();
-                outputStream.println("View scan results at:");
-                outputStream.println("\t" + reportPath.toUri());
-                outputStream.println();
-                if (scanReport) {
-                    Path scanReportPath = ScanUtils.generateScanReport(issues, project.get(), targetDir);
+
+                if (project.workspaceProject().isEmpty()) {
                     outputStream.println();
-                    outputStream.println("View scan report at:");
-                    outputStream.println("\t" + scanReportPath.toUri() + System.lineSeparator());
+                    outputStream.println("View scan results at:");
+                    outputStream.println("\t" + reportPath.toUri());
+                    outputStream.println();
+                    if (scanReport) {
+                        Path scanReportPath = ScanUtils.generateScanReport(issues, project, targetDir);
+                        outputStream.println();
+                        outputStream.println("View scan report at:");
+                        outputStream.println("\t" + scanReportPath.toUri() + System.lineSeparator());
+                    }
                 }
             } else {
                 if (targetDir != null) {
@@ -315,10 +394,20 @@ public class ScanCmd implements BLauncherCmd {
 
     protected Optional<Project> getProject() {
         try {
-            if (projectPath.toFile().isDirectory()) {
-                return Optional.of(BuildProject.load(projectPath));
+            if (!ProjectPaths.isBuildProjectRoot(projectPath)
+                    && !ProjectPaths.isStandaloneBalFile(projectPath)
+                    && !ProjectPaths.isWorkspaceProjectRoot(projectPath)) {
+                outputStream.println("The specified path is not a valid Ballerina project: " + projectPath + ". Please "
+                        + "provide a valid Ballerina project path and try again.");
+                return Optional.empty();
             }
-            return Optional.of(SingleFileProject.load(projectPath));
+
+            ProjectLoadResult loadResult = ProjectLoader.load(projectPath);
+            if (loadResult.diagnostics().hasErrors()) {
+                loadResult.diagnostics().errors().forEach(outputStream::println);
+                return Optional.empty();
+            }
+            return Optional.of(loadResult.project());
         } catch (RuntimeException ex) {
             outputStream.println(ex.getMessage());
             return Optional.empty();

--- a/scan-command/src/main/java/io/ballerina/scan/utils/Constants.java
+++ b/scan-command/src/main/java/io/ballerina/scan/utils/Constants.java
@@ -18,6 +18,7 @@
 
 package io.ballerina.scan.utils;
 
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Properties;
@@ -28,8 +29,8 @@ import java.util.Properties;
  * @since 0.1.0
  */
 public class Constants {
-    static final String RESULTS_JSON_FILE = "scan_results.json";
-    static final String RESULTS_SARIF_FILE = "scan_results.sarif";
+    public static final String RESULTS_JSON_FILE = "scan_results.json";
+    public static final String RESULTS_SARIF_FILE = "scan_results.sarif";
     static final String RESULTS_HTML_FILE = "index.html";
     static final String REPORT_DATA_PLACEHOLDER = "__data__";
     static final String SCAN_REPORT_PROJECT_NAME = "projectName";

--- a/scan-command/src/main/java/io/ballerina/scan/utils/ScanUtils.java
+++ b/scan-command/src/main/java/io/ballerina/scan/utils/ScanUtils.java
@@ -64,12 +64,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import static io.ballerina.projects.util.ProjectConstants.LOCAL_REPOSITORY_NAME;
-import static io.ballerina.projects.util.ProjectConstants.USER_DIR_PROPERTY;
 import static io.ballerina.scan.utils.Constants.ANALYZER_NAME;
 import static io.ballerina.scan.utils.Constants.ANALYZER_ORG;
 import static io.ballerina.scan.utils.Constants.ANALYZER_REPOSITORY;
@@ -164,7 +164,16 @@ public final class ScanUtils {
     public static String convertIssuesToJsonString(List<Issue> issues) {
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         JsonArray issuesAsJson = gson.toJsonTree(issues).getAsJsonArray();
-        return gson.toJson(issuesAsJson);
+        String json = gson.toJson(issuesAsJson);
+        if (File.separator.equals("\\")) {
+            // Gson JSON-escapes backslashes in fileName (\ -> \\), but fileName is a display field
+            // that should preserve the OS-native single backslash separator as-is.
+            Pattern p = Pattern.compile("(\"fileName\"\\s*:\\s*\")([^\"]*)(\")", Pattern.MULTILINE);
+            Matcher m = p.matcher(json);
+            json = m.replaceAll(mr -> Matcher.quoteReplacement(
+                    mr.group(1) + mr.group(2).replace("\\\\", "\\") + mr.group(3)));
+        }
+        return json;
     }
 
     /**
@@ -175,7 +184,7 @@ public final class ScanUtils {
      * @param project Ballerina project
      * @return SARIF string representation of generated issues
      */
-    private static String convertIssuesToSarifString(List<Issue> issues, Project project) {
+    public static String convertIssuesToSarifString(List<Issue> issues, Project project) {
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
         // Create SARIF root object
@@ -569,7 +578,7 @@ public final class ScanUtils {
 
         Path targetDir = project.targetDir();
         if (ballerinaTomlDocumentContent.getTable(SCAN_TABLE).isEmpty()) {
-            Path scanTomlFilePath = Path.of(System.getProperty(USER_DIR_PROPERTY)).resolve(SCAN_FILE);
+            Path scanTomlFilePath = project.sourceRoot().resolve(SCAN_FILE);
             if (Files.exists(scanTomlFilePath)) {
                 outputStream.println("Loading scan tool configurations from " + scanTomlFilePath);
                 return loadScanFile(targetDir, scanTomlFilePath, outputStream);

--- a/scan-command/src/main/java/io/ballerina/scan/utils/ScanUtils.java
+++ b/scan-command/src/main/java/io/ballerina/scan/utils/ScanUtils.java
@@ -161,7 +161,7 @@ public final class ScanUtils {
      * @param issues generated issues
      * @return json string array of generated issues
      */
-    private static String convertIssuesToJsonString(List<Issue> issues) {
+    public static String convertIssuesToJsonString(List<Issue> issues) {
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
         JsonArray issuesAsJson = gson.toJsonTree(issues).getAsJsonArray();
         return gson.toJson(issuesAsJson);
@@ -396,7 +396,7 @@ public final class ScanUtils {
      * @param directoryName target directory name
      * @return generated target directory
      */
-    private static Target getTargetPath(Project project, String directoryName) {
+    public static Target getTargetPath(Project project, String directoryName) {
         try {
             if (directoryName == null) {
                 return new Target(project.targetDir());
@@ -423,7 +423,13 @@ public final class ScanUtils {
      */
     public static Path generateScanReport(List<Issue> issues, Project project, String directoryName) {
         JsonObject scannedProject = new JsonObject();
-        scannedProject.addProperty(SCAN_REPORT_PROJECT_NAME, project.currentPackage().packageName().toString());
+        String name;
+        if (project.kind() == ProjectKind.WORKSPACE_PROJECT) {
+            name = Optional.of(project.sourceRoot().getFileName()).get().toString();
+        } else {
+            name = project.currentPackage().packageName().toString();
+        }
+        scannedProject.addProperty(SCAN_REPORT_PROJECT_NAME, name);
         Map<String, JsonObject> scanReportPathAndFile = new HashMap<>();
 
         for (Issue issue : issues) {
@@ -503,8 +509,8 @@ public final class ScanUtils {
         scanReportIssueTextRange.addProperty(SCAN_REPORT_ISSUE_TEXT_RANGE_START_LINE, lineRange.startLine().line());
         scanReportIssueTextRange.addProperty(SCAN_REPORT_ISSUE_TEXT_RANGE_START_LINE_OFFSET, lineRange.startLine()
                 .offset());
-        scanReportIssueTextRange.addProperty(SCAN_REPORT_ISSUE_TEXT_RANGE_END_LINE, lineRange.endLine().line());
-        scanReportIssueTextRange.addProperty(SCAN_REPORT_ISSUE_TEXT_RANGE_END_LINE_OFFSET, lineRange.endLine()
+        scanReportIssueTextRange.addProperty(SCAN_REPORT_ISSUE_TEXT_RANGE_END_LINE, (int) lineRange.endLine().line());
+        scanReportIssueTextRange.addProperty(SCAN_REPORT_ISSUE_TEXT_RANGE_END_LINE_OFFSET, (int) lineRange.endLine()
                 .offset());
 
         scanReportIssue.add(SCAN_REPORT_ISSUE_TEXT_RANGE, scanReportIssueTextRange);

--- a/scan-command/src/test/java/io/ballerina/scan/internal/ProjectAnalyzerTest.java
+++ b/scan-command/src/test/java/io/ballerina/scan/internal/ProjectAnalyzerTest.java
@@ -23,7 +23,7 @@ import io.ballerina.projects.Document;
 import io.ballerina.projects.DocumentId;
 import io.ballerina.projects.Module;
 import io.ballerina.projects.Project;
-import io.ballerina.projects.directory.BuildProject;
+import io.ballerina.projects.directory.ProjectLoader;
 import io.ballerina.scan.BaseTest;
 import io.ballerina.scan.Issue;
 import io.ballerina.scan.Rule;
@@ -51,8 +51,8 @@ import static io.ballerina.scan.TestConstants.WINDOWS_LINE_SEPARATOR;
  * @since 0.1.0
  */
 public class ProjectAnalyzerTest extends BaseTest {
-    private final Project project = BuildProject.load(testResources.resolve("test-resources")
-            .resolve("bal-project-with-config-file"));
+    private final Project project = ProjectLoader.load(testResources.resolve("test-resources")
+            .resolve("bal-project-with-config-file")).project();
     private ProjectAnalyzer projectAnalyzer = null;
 
     @BeforeMethod
@@ -153,8 +153,8 @@ public class ProjectAnalyzerTest extends BaseTest {
 
     @Test(description = "Test analyzing project with invalid external analyzer rules.json configurations")
     void testAnalyzingProjectWithInvalidExternalAnalyzerRules() throws IOException {
-        Project invalidProject = BuildProject.load(testResources.resolve("test-resources")
-                .resolve("bal-project-with-invalid-external-analyzer-rules"));
+        Project invalidProject = ProjectLoader.load(testResources.resolve("test-resources")
+                .resolve("bal-project-with-invalid-external-analyzer-rules")).project();
         System.setProperty("user.dir", invalidProject.sourceRoot().toString());
         ScanTomlFile scanTomlFile = ScanUtils.loadScanTomlConfigurations(invalidProject, printStream)
                 .orElse(null);
@@ -175,8 +175,8 @@ public class ProjectAnalyzerTest extends BaseTest {
 
     @Test(description = "Test analyzing project with invalid external analyzer rule format")
     void testAnalyzingProjectWithInvalidExternalAnalyzerRuleFormat() throws IOException {
-        Project invalidProject = BuildProject.load(testResources.resolve("test-resources")
-                .resolve("bal-project-with-invalid-external-analyzer-rule-format"));
+        Project invalidProject = ProjectLoader.load(testResources.resolve("test-resources")
+                .resolve("bal-project-with-invalid-external-analyzer-rule-format")).project();
         System.setProperty("user.dir", invalidProject.sourceRoot().toString());
         ScanTomlFile scanTomlFile = ScanUtils.loadScanTomlConfigurations(invalidProject, printStream)
                 .orElse(null);
@@ -197,8 +197,8 @@ public class ProjectAnalyzerTest extends BaseTest {
 
     @Test(description = "Test analyzing project with invalid external analyzer rule kind")
     void testAnalyzingProjectWithInvalidExternalAnalyzerRuleKind() throws IOException {
-        Project invalidProject = BuildProject.load(testResources.resolve("test-resources")
-                .resolve("bal-project-with-invalid-external-analyzer-rule-kind"));
+        Project invalidProject = ProjectLoader.load(testResources.resolve("test-resources")
+                .resolve("bal-project-with-invalid-external-analyzer-rule-kind")).project();
         System.setProperty("user.dir", invalidProject.sourceRoot().toString());
         ScanTomlFile scanTomlFile = ScanUtils.loadScanTomlConfigurations(invalidProject, printStream)
                 .orElse(null);

--- a/scan-command/src/test/java/io/ballerina/scan/internal/ReporterImplTest.java
+++ b/scan-command/src/test/java/io/ballerina/scan/internal/ReporterImplTest.java
@@ -22,7 +22,7 @@ import io.ballerina.compiler.syntax.tree.ModulePartNode;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Module;
 import io.ballerina.projects.Project;
-import io.ballerina.projects.directory.SingleFileProject;
+import io.ballerina.projects.directory.ProjectLoader;
 import io.ballerina.scan.Issue;
 import io.ballerina.scan.Rule;
 import io.ballerina.scan.RuleKind;
@@ -54,7 +54,7 @@ public class ReporterImplTest {
         ReporterImpl reporter = new ReporterImpl(Collections.singletonList(rule));
         Path validBalProject = Paths.get("src", "test", "resources", "test-resources",
                 "valid-single-file-project", "main.bal");
-        Project project = SingleFileProject.load(validBalProject);
+        Project project = ProjectLoader.load(validBalProject).project();
         Module defaultModule = project.currentPackage().getDefaultModule();
         Document document = defaultModule.document(defaultModule.documentIds().iterator().next());
         ModulePartNode modulePartNode = document.syntaxTree().rootNode();
@@ -84,7 +84,7 @@ public class ReporterImplTest {
         ReporterImpl reporter = new ReporterImpl(rules);
         Path validBalProject = Paths.get("src", "test", "resources", "test-resources",
                 "valid-single-file-project", "main.bal");
-        Project project = SingleFileProject.load(validBalProject);
+        Project project = ProjectLoader.load(validBalProject).project();
         Module defaultModule = project.currentPackage().getDefaultModule();
         Document document = defaultModule.document(defaultModule.documentIds().iterator().next());
         ModulePartNode modulePartNode = document.syntaxTree().rootNode();
@@ -110,7 +110,7 @@ public class ReporterImplTest {
         ReporterImpl reporter = new ReporterImpl(rules);
         Path validBalProject = Paths.get("src", "test", "resources", "test-resources",
                 "valid-single-file-project", "main.bal");
-        Project project = SingleFileProject.load(validBalProject);
+        Project project = ProjectLoader.load(validBalProject).project();
         Module defaultModule = project.currentPackage().getDefaultModule();
         Document document = defaultModule.document(defaultModule.documentIds().iterator().next());
         ModulePartNode modulePartNode = document.syntaxTree().rootNode();
@@ -137,7 +137,7 @@ public class ReporterImplTest {
         ReporterImpl reporter = new ReporterImpl(rules);
         Path validBalProject = Paths.get("src", "test", "resources", "test-resources",
                 "valid-single-file-project", "main.bal");
-        Project project = SingleFileProject.load(validBalProject);
+        Project project = ProjectLoader.load(validBalProject).project();
         Module defaultModule = project.currentPackage().getDefaultModule();
         Document document = defaultModule.document(defaultModule.documentIds().iterator().next());
         ModulePartNode modulePartNode = (ModulePartNode) document.syntaxTree().rootNode();
@@ -166,7 +166,7 @@ public class ReporterImplTest {
         ReporterImpl reporter = new ReporterImpl(rules);
         Path validBalProject = Paths.get("src", "test", "resources", "test-resources",
                 "valid-single-file-project", "main.bal");
-        Project project = SingleFileProject.load(validBalProject);
+        Project project = ProjectLoader.load(validBalProject).project();
         Module defaultModule = project.currentPackage().getDefaultModule();
         Document document = defaultModule.document(defaultModule.documentIds().iterator().next());
         ModulePartNode modulePartNode = (ModulePartNode) document.syntaxTree().rootNode();

--- a/scan-command/src/test/java/io/ballerina/scan/internal/ScanCmdTest.java
+++ b/scan-command/src/test/java/io/ballerina/scan/internal/ScanCmdTest.java
@@ -245,8 +245,10 @@ public class ScanCmdTest extends BaseTest {
         List<Rule> rules = CoreRule.rules();
         externalAnalyzers.values().forEach(rules::addAll);
         ScanUtils.printRulesToConsole(rules, printStream);
-        String expected = getExpectedOutput("print-rules-to-console.txt");
-        Assert.assertEquals(readOutput(true).trim(), expected);
+        String expected = getExpectedOutput("print-rules-to-console.txt").replace("<ABS_SOURCE_ROOT>",
+                ballerinaProject.toAbsolutePath().toString());
+        String actual = readOutput(true).trim();
+        Assert.assertEquals(actual, expected);
     }
 
     @Test(description = "test scan command with list rules flag")
@@ -259,8 +261,10 @@ public class ScanCmdTest extends BaseTest {
         new CommandLine(scanCmd).parseArgs(args);
         scanCmd.execute();
         System.setProperty("user.dir", userDir);
-        String expected = getExpectedOutput("list-rules-output.txt");
-        Assert.assertEquals(readOutput(true).trim(), expected);
+        String expected = getExpectedOutput("list-rules-output.txt").replace("<ABS_SOURCE_ROOT>",
+                ballerinaProject.toAbsolutePath().toString());
+        String actual = readOutput(true).trim();
+        Assert.assertEquals(actual, expected);
     }
 
     @Test(description = "test scan command with target directory flag on single file project")
@@ -352,8 +356,8 @@ public class ScanCmdTest extends BaseTest {
         String result = Files.readString(ballerinaProject.resolve("target").resolve("report")
                         .resolve("scan_results.json"), StandardCharsets.UTF_8)
                 .replace(WINDOWS_LINE_SEPARATOR, LINUX_LINE_SEPARATOR);
-        String expected = getExpectedOutput("include-rules-issues-report.txt").replaceAll("<ABS_SOURCE_ROOT>",
-                ballerinaProject.toAbsolutePath().toString());
+        String expected = getExpectedOutput("include-rules-issues-report.txt").replace("<ABS_SOURCE_ROOT>",
+                ballerinaProject.toAbsolutePath().toString().replace("\\", "\\\\"));
         Assert.assertEquals(result, expected);
     }
 
@@ -368,10 +372,35 @@ public class ScanCmdTest extends BaseTest {
         System.setProperty("user.dir", userDir);
         String result = Files.readString(ballerinaProject.resolve("target").resolve("report")
                         .resolve("scan_results.json"), StandardCharsets.UTF_8)
-                .replace(WINDOWS_LINE_SEPARATOR, LINUX_LINE_SEPARATOR);
-        String expected = getExpectedOutput("workspace-issues.txt").replaceAll("<ABS_SOURCE_ROOT>",
-                ballerinaProject.toAbsolutePath().toString());
+                .replace(WINDOWS_LINE_SEPARATOR, LINUX_LINE_SEPARATOR);;
+        String expected = getExpectedOutput("workspace-issues.txt")
+                .replace("<ABS_SOURCE_ROOT>", ballerinaProject.toAbsolutePath().toString()
+                        .replace("\\", "\\\\"));
         Assert.assertEquals(result, expected);
+    }
+
+    @Test(description = "test scan command in workspace with sarif format")
+    void testScanCommandInWorkspaceWithSarif() throws IOException {
+        Path workspacePath = testResources.resolve("test-resources").resolve("workspace-project");
+        System.setProperty("user.dir", workspacePath.toString());
+        ScanCmd scanCmd = new ScanCmd(printStream);
+        String[] args = {"--format=sarif", "--include-rules=ballerina:1"};
+        new CommandLine(scanCmd).parseArgs(args);
+        scanCmd.execute();
+        System.setProperty("user.dir", userDir);
+
+        Path sarifReport = workspacePath.resolve("target").resolve("report").resolve("scan_results.sarif");
+        Assert.assertTrue(Files.exists(sarifReport), "SARIF report should be created at workspace level");
+
+        String content = Files.readString(sarifReport, StandardCharsets.UTF_8)
+                .replace(WINDOWS_LINE_SEPARATOR, LINUX_LINE_SEPARATOR);
+        Assert.assertTrue(content.contains("\"version\": \"2.1.0\""), "SARIF should have version 2.1.0");
+        Assert.assertTrue(
+                content.contains("\"bal-project-with-analyzer-configurations/main.bal\""),
+                "SARIF URI should be relative to workspace root for first sub-project");
+        Assert.assertTrue(
+                content.contains("\"bal-project-with-include-rule-configurations/main.bal\""),
+                "SARIF URI should be relative to workspace root for second sub-project");
     }
 
     @Test(description = "test scan command with exclude rules flag")
@@ -387,8 +416,8 @@ public class ScanCmdTest extends BaseTest {
         String result = Files.readString(ballerinaProject.resolve("target").resolve("report")
                         .resolve("scan_results.json"), StandardCharsets.UTF_8)
                 .replace(WINDOWS_LINE_SEPARATOR, LINUX_LINE_SEPARATOR);
-        String expected = getExpectedOutput("exclude-rules-issues-report.txt").replaceAll("<ABS_SOURCE_ROOT>",
-                ballerinaProject.toAbsolutePath().toString());
+        String expected = getExpectedOutput("exclude-rules-issues-report.txt").replace("<ABS_SOURCE_ROOT>",
+                ballerinaProject.toAbsolutePath().toString().replace("\\", "\\\\"));
         Assert.assertEquals(result, expected);
     }
 
@@ -402,8 +431,10 @@ public class ScanCmdTest extends BaseTest {
         new CommandLine(scanCmd).parseArgs(args);
         scanCmd.execute();
         System.setProperty("user.dir", userDir);
-        String expected = getExpectedOutput("include-exclude-rules.txt").trim();
-        Assert.assertEquals(readOutput(true).trim(), expected);
+        String expected = getExpectedOutput("include-exclude-rules.txt").trim().replace("<ABS_SOURCE_ROOT>",
+                ballerinaProject.toAbsolutePath().toString());
+        String actual = readOutput(true).trim();
+        Assert.assertEquals(actual, expected);
     }
 
     @Test(description = "test scan command with include rules Scan.toml configurations")
@@ -417,8 +448,8 @@ public class ScanCmdTest extends BaseTest {
         String result = Files.readString(ballerinaProject.resolve("target").resolve("report")
                         .resolve("scan_results.json"), StandardCharsets.UTF_8)
                 .replace(WINDOWS_LINE_SEPARATOR, LINUX_LINE_SEPARATOR);
-        String expected = getExpectedOutput("toml-include-rules-issues-report.txt").replaceAll("<ABS_SOURCE_ROOT>",
-                ballerinaProject.toAbsolutePath().toString());
+        String expected = getExpectedOutput("toml-include-rules-issues-report.txt").replace("<ABS_SOURCE_ROOT>",
+                ballerinaProject.toAbsolutePath().toString().replace("\\", "\\\\"));
         Assert.assertEquals(result, expected);
     }
 
@@ -435,8 +466,8 @@ public class ScanCmdTest extends BaseTest {
         String result = Files.readString(ballerinaProject.resolve("target").resolve("report")
                         .resolve("scan_results.json"), StandardCharsets.UTF_8)
                 .replace(WINDOWS_LINE_SEPARATOR, LINUX_LINE_SEPARATOR);
-        String expected = getExpectedOutput("toml-exclude-rules-issues-report.txt").replaceAll("<ABS_SOURCE_ROOT>",
-                ballerinaProject.toAbsolutePath().toString());
+        String expected = getExpectedOutput("toml-exclude-rules-issues-report.txt").replace("<ABS_SOURCE_ROOT>",
+                ballerinaProject.toAbsolutePath().toString().replace("\\", "\\\\"));
         Assert.assertEquals(result, expected);
     }
 
@@ -450,8 +481,10 @@ public class ScanCmdTest extends BaseTest {
         new CommandLine(scanCmd).parseArgs(args);
         scanCmd.execute();
         System.setProperty("user.dir", userDir);
-        String expected = getExpectedOutput("toml-include-exclude-rules.txt");
-        Assert.assertEquals(readOutput(true).trim(), expected);
+        String expected = getExpectedOutput("toml-include-exclude-rules.txt").replace("<ABS_SOURCE_ROOT>",
+                ballerinaProject.toAbsolutePath().toString());
+        String actual = readOutput(true).trim();
+        Assert.assertEquals(actual, expected);
     }
 
     @Test(description = "test scan command with platform plugin configurations")
@@ -489,11 +522,11 @@ public class ScanCmdTest extends BaseTest {
                 .replace(WINDOWS_LINE_SEPARATOR, LINUX_LINE_SEPARATOR);
         removeFile(result);
 
-        String expected = getExpectedOutput("platform-plugin-issue-output.txt").replaceAll("<ABS_SOURCE_ROOT>",
-                ballerinaProject.toAbsolutePath().toString());
+        String expected = getExpectedOutput("platform-plugin-issue-output.txt").replace("<ABS_SOURCE_ROOT>",
+                ballerinaProject.toAbsolutePath().toString().replace("\\", "\\\\"));
         Assert.assertEquals(platformIssuesOutput, expected);
 
-        expected = getExpectedOutput("platform-plugin-arguments-output.txt").replaceAll("<ABS_SOURCE_ROOT>",
+        expected = getExpectedOutput("platform-plugin-arguments-output.txt").replace("<ABS_SOURCE_ROOT>",
                 ballerinaProject.toAbsolutePath().toString());
         Assert.assertEquals(platformArgumentsOutput, expected);
     }
@@ -522,7 +555,9 @@ public class ScanCmdTest extends BaseTest {
         ScanCmd scanCmd = new ScanCmd(printStream);
         scanCmd.execute();
         System.setProperty("user.dir", userDir);
-        String expected = getExpectedOutput("invalid-platform-plugin-configurations.txt");
+        String expected = getExpectedOutput("invalid-platform-plugin-configurations.txt")
+                .replace("<ABS_SOURCE_ROOT>",
+                ballerinaProject.toAbsolutePath().toString());
         Assert.assertEquals(readOutput(true).trim(), expected);
     }
 

--- a/scan-command/src/test/java/io/ballerina/scan/internal/ScanCmdTest.java
+++ b/scan-command/src/test/java/io/ballerina/scan/internal/ScanCmdTest.java
@@ -19,7 +19,6 @@
 package io.ballerina.scan.internal;
 
 import io.ballerina.projects.Project;
-import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.directory.ProjectLoader;
 import io.ballerina.projects.util.ProjectUtils;
 import io.ballerina.scan.BaseTest;
@@ -121,17 +120,19 @@ public class ScanCmdTest extends BaseTest {
         scanCmd.execute();
         System.setProperty("user.dir", userDir);
         String expected = error(EMPTY_PACKAGE);
-        Assert.assertEquals(readOutput(true).trim().split("\n")[0], expected);
+        String actual = readOutput(true).trim().split("\n")[0];
+        Assert.assertEquals(actual, expected);
     }
 
     @Test(description = "test scan command with Ballerina project with single file as argument")
     void testScanCommandProjectWithArgument() throws IOException {
         ScanCmd scanCmd = new ScanCmd(printStream);
-        String[] args = {validBalProject.resolve("main.bal").toString()};
+        String inputPath = validBalProject.resolve("main.bal").toString();
+        String[] args = {inputPath};
         new CommandLine(scanCmd).parseArgs(args);
         scanCmd.execute();
-        String expected = "The source file '" + validBalProject.resolve("main.bal") +
-                "' belongs to a Ballerina package.";
+        String expected = "The specified path is not a valid Ballerina project: " + inputPath + ". Please "
+                + "provide a valid Ballerina project path and try again.";
         Assert.assertEquals(readOutput(true).trim().split("\n")[0], expected);
     }
 
@@ -150,11 +151,12 @@ public class ScanCmdTest extends BaseTest {
     void testScanCommandSingleFileProjectWithDirectoryAsArgument() throws IOException {
         Path parentDirectory = testResources.resolve("test-resources").toAbsolutePath();
         ScanCmd scanCmd = new ScanCmd(printStream);
-        String[] args = {parentDirectory.resolve("valid-single-file-project").toString()};
+        String inputPath = parentDirectory.resolve("valid-single-file-project").toString();
+        String[] args = {inputPath};
         new CommandLine(scanCmd).parseArgs(args);
         scanCmd.execute();
-        String expected = "Invalid Ballerina package directory: " +
-                parentDirectory.resolve("valid-single-file-project") + ", cannot find 'Ballerina.toml' file.";
+        String expected = "The specified path is not a valid Ballerina project: " + inputPath + ". Please "
+                + "provide a valid Ballerina project path and try again.";
         Assert.assertEquals(readOutput(true).trim(), expected);
     }
 
@@ -165,8 +167,8 @@ public class ScanCmdTest extends BaseTest {
         ScanCmd scanCmd = new ScanCmd(printStream);
         scanCmd.execute();
         System.setProperty("user.dir", userDir);
-        String expected = "Invalid Ballerina package directory: " + validBalProject +
-                ", cannot find 'Ballerina.toml' file.";
+        String expected = "The specified path is not a valid Ballerina project: " + validBalProject + ". Please "
+                + "provide a valid Ballerina project path and try again.";
         Assert.assertEquals(readOutput(true).trim(), expected);
     }
 
@@ -199,7 +201,7 @@ public class ScanCmdTest extends BaseTest {
                 validBalProject.resolve("main.bal").toString()));
         issues.add(new IssueImpl(location, externalRule, Source.EXTERNAL, "main.bal",
                 validBalProject.resolve("main.bal").toString()));
-        Project project = ProjectLoader.loadProject(validBalProject);
+        Project project = ProjectLoader.load(validBalProject).project();
         Path resultsFile = ScanUtils.saveToDirectory(issues, project, null);
         String result = Files.readString(resultsFile, StandardCharsets.UTF_8)
                 .replace(WINDOWS_LINE_SEPARATOR, LINUX_LINE_SEPARATOR);
@@ -220,7 +222,7 @@ public class ScanCmdTest extends BaseTest {
                 validBalProject.resolve("main.bal").toString()));
         issues.add(new IssueImpl(location, externalRule, Source.EXTERNAL, "main.bal",
                 validBalProject.resolve("main.bal").toString()));
-        Project project = ProjectLoader.loadProject(validBalProject);
+        Project project = ProjectLoader.load(validBalProject).project();
         Path resultsFile = ScanUtils.generateScanReport(issues, project, null);
         String result = Files.readString(resultsFile, StandardCharsets.UTF_8)
                 .replace(WINDOWS_LINE_SEPARATOR, LINUX_LINE_SEPARATOR);
@@ -232,7 +234,7 @@ public class ScanCmdTest extends BaseTest {
     void testPrintRulesToConsole() throws IOException {
         Path ballerinaProject = testResources.resolve("test-resources")
                 .resolve("bal-project-with-config-file");
-        Project project = BuildProject.load(ballerinaProject);
+        Project project = ProjectLoader.load(ballerinaProject).project();
         System.setProperty("user.dir", ballerinaProject.toString());
         ScanTomlFile scanTomlFile = ScanUtils.loadScanTomlConfigurations(project, printStream).orElse(null);
         Assert.assertNotNull(scanTomlFile);
@@ -350,7 +352,25 @@ public class ScanCmdTest extends BaseTest {
         String result = Files.readString(ballerinaProject.resolve("target").resolve("report")
                         .resolve("scan_results.json"), StandardCharsets.UTF_8)
                 .replace(WINDOWS_LINE_SEPARATOR, LINUX_LINE_SEPARATOR);
-        String expected = getExpectedOutput("include-rules-issues-report.txt");
+        String expected = getExpectedOutput("include-rules-issues-report.txt").replaceAll("<ABS_SOURCE_ROOT>",
+                ballerinaProject.toAbsolutePath().toString());
+        Assert.assertEquals(result, expected);
+    }
+
+    @Test(description = "test scan command with include rules flag")
+    void testScanCommandInWorkspace() throws IOException {
+        Path ballerinaProject = testResources.resolve("test-resources").resolve("workspace-project");
+        System.setProperty("user.dir", ballerinaProject.toString());
+        ScanCmd scanCmd = new ScanCmd(printStream);
+        String[] args = {"--include-rules=ballerina:1"};
+        new CommandLine(scanCmd).parseArgs(args);
+        scanCmd.execute();
+        System.setProperty("user.dir", userDir);
+        String result = Files.readString(ballerinaProject.resolve("target").resolve("report")
+                        .resolve("scan_results.json"), StandardCharsets.UTF_8)
+                .replace(WINDOWS_LINE_SEPARATOR, LINUX_LINE_SEPARATOR);
+        String expected = getExpectedOutput("workspace-issues.txt").replaceAll("<ABS_SOURCE_ROOT>",
+                ballerinaProject.toAbsolutePath().toString());
         Assert.assertEquals(result, expected);
     }
 
@@ -367,7 +387,8 @@ public class ScanCmdTest extends BaseTest {
         String result = Files.readString(ballerinaProject.resolve("target").resolve("report")
                         .resolve("scan_results.json"), StandardCharsets.UTF_8)
                 .replace(WINDOWS_LINE_SEPARATOR, LINUX_LINE_SEPARATOR);
-        String expected = getExpectedOutput("exclude-rules-issues-report.txt");
+        String expected = getExpectedOutput("exclude-rules-issues-report.txt").replaceAll("<ABS_SOURCE_ROOT>",
+                ballerinaProject.toAbsolutePath().toString());
         Assert.assertEquals(result, expected);
     }
 
@@ -381,7 +402,7 @@ public class ScanCmdTest extends BaseTest {
         new CommandLine(scanCmd).parseArgs(args);
         scanCmd.execute();
         System.setProperty("user.dir", userDir);
-        String expected = getExpectedOutput("include-exclude-rules.txt");
+        String expected = getExpectedOutput("include-exclude-rules.txt").trim();
         Assert.assertEquals(readOutput(true).trim(), expected);
     }
 
@@ -396,7 +417,8 @@ public class ScanCmdTest extends BaseTest {
         String result = Files.readString(ballerinaProject.resolve("target").resolve("report")
                         .resolve("scan_results.json"), StandardCharsets.UTF_8)
                 .replace(WINDOWS_LINE_SEPARATOR, LINUX_LINE_SEPARATOR);
-        String expected = getExpectedOutput("toml-include-rules-issues-report.txt");
+        String expected = getExpectedOutput("toml-include-rules-issues-report.txt").replaceAll("<ABS_SOURCE_ROOT>",
+                ballerinaProject.toAbsolutePath().toString());
         Assert.assertEquals(result, expected);
     }
 
@@ -413,7 +435,8 @@ public class ScanCmdTest extends BaseTest {
         String result = Files.readString(ballerinaProject.resolve("target").resolve("report")
                         .resolve("scan_results.json"), StandardCharsets.UTF_8)
                 .replace(WINDOWS_LINE_SEPARATOR, LINUX_LINE_SEPARATOR);
-        String expected = getExpectedOutput("toml-exclude-rules-issues-report.txt");
+        String expected = getExpectedOutput("toml-exclude-rules-issues-report.txt").replaceAll("<ABS_SOURCE_ROOT>",
+                ballerinaProject.toAbsolutePath().toString());
         Assert.assertEquals(result, expected);
     }
 
@@ -466,10 +489,12 @@ public class ScanCmdTest extends BaseTest {
                 .replace(WINDOWS_LINE_SEPARATOR, LINUX_LINE_SEPARATOR);
         removeFile(result);
 
-        String expected = getExpectedOutput("platform-plugin-issue-output.txt");
+        String expected = getExpectedOutput("platform-plugin-issue-output.txt").replaceAll("<ABS_SOURCE_ROOT>",
+                ballerinaProject.toAbsolutePath().toString());
         Assert.assertEquals(platformIssuesOutput, expected);
 
-        expected = getExpectedOutput("platform-plugin-arguments-output.txt");
+        expected = getExpectedOutput("platform-plugin-arguments-output.txt").replaceAll("<ABS_SOURCE_ROOT>",
+                ballerinaProject.toAbsolutePath().toString());
         Assert.assertEquals(platformArgumentsOutput, expected);
     }
 

--- a/scan-command/src/test/java/io/ballerina/scan/internal/ScanCmdTest.java
+++ b/scan-command/src/test/java/io/ballerina/scan/internal/ScanCmdTest.java
@@ -361,7 +361,7 @@ public class ScanCmdTest extends BaseTest {
         Assert.assertEquals(result, expected);
     }
 
-    @Test(description = "test scan command with include rules flag")
+    @Test(description = "test scan command in workspace")
     void testScanCommandInWorkspace() throws IOException {
         Path ballerinaProject = testResources.resolve("test-resources").resolve("workspace-project");
         System.setProperty("user.dir", ballerinaProject.toString());
@@ -372,7 +372,7 @@ public class ScanCmdTest extends BaseTest {
         System.setProperty("user.dir", userDir);
         String result = Files.readString(ballerinaProject.resolve("target").resolve("report")
                         .resolve("scan_results.json"), StandardCharsets.UTF_8)
-                .replace(WINDOWS_LINE_SEPARATOR, LINUX_LINE_SEPARATOR);;
+                .replace(WINDOWS_LINE_SEPARATOR, LINUX_LINE_SEPARATOR);
         String expected = getExpectedOutput("workspace-issues.txt")
                 .replace("<ABS_SOURCE_ROOT>", ballerinaProject.toAbsolutePath().toString()
                         .replace("\\", "\\\\"));

--- a/scan-command/src/test/java/io/ballerina/scan/internal/StaticCodeAnalyzerTest.java
+++ b/scan-command/src/test/java/io/ballerina/scan/internal/StaticCodeAnalyzerTest.java
@@ -21,7 +21,7 @@ package io.ballerina.scan.internal;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Module;
 import io.ballerina.projects.Project;
-import io.ballerina.projects.directory.SingleFileProject;
+import io.ballerina.projects.directory.ProjectLoader;
 import io.ballerina.scan.BaseTest;
 import io.ballerina.scan.Issue;
 import io.ballerina.scan.Rule;
@@ -41,7 +41,7 @@ public class StaticCodeAnalyzerTest extends BaseTest {
     private final Path coreRuleBalFiles = testResources.resolve("test-resources").resolve("core-rules");
 
     Document loadDocument(String documentName) {
-        Project project = SingleFileProject.load(coreRuleBalFiles.resolve(documentName));
+        Project project = ProjectLoader.load(coreRuleBalFiles.resolve(documentName)).project();
         Module defaultModule = project.currentPackage().getDefaultModule();
         return defaultModule.document(defaultModule.documentIds().iterator().next());
     }

--- a/scan-command/src/test/java/io/ballerina/scan/utils/ScanUtilsTest.java
+++ b/scan-command/src/test/java/io/ballerina/scan/utils/ScanUtilsTest.java
@@ -256,7 +256,8 @@ public class ScanUtilsTest extends BaseTest {
         Assert.assertEquals(readOutput(true).trim(), expected);
     }
 
-    @Test(description = "test method for loading configurations from a remote configuration file")
+    @Test(enabled = false, // the remote toml location is not available due to the missing bot account
+            description = "test method for loading configurations from a remote configuration file")
     void testLoadRemoteScanTomlConfigurations() {
         Path ballerinaProject = testResources.resolve("test-resources")
                 .resolve("bal-project-with-remote-config-file");

--- a/scan-command/src/test/java/io/ballerina/scan/utils/ScanUtilsTest.java
+++ b/scan-command/src/test/java/io/ballerina/scan/utils/ScanUtilsTest.java
@@ -112,7 +112,7 @@ public class ScanUtilsTest extends BaseTest {
 
     @Test(description =
             "test method for loading configurations from a Scan.toml file in a Ballerina single file project")
-    void testloadScanTomlConfigurationsForSingleFileProject() {
+    void testLoadScanTomlConfigurationsForSingleFileProject() {
         Path ballerinaProject = testResources.resolve("test-resources")
                 .resolve("single-file-project-with-config-file").resolve("main.bal");
         Project project = ProjectLoader.load(ballerinaProject).project();
@@ -170,7 +170,8 @@ public class ScanUtilsTest extends BaseTest {
         ScanTomlFile scanTomlFile = ScanUtils.loadScanTomlConfigurations(project, printStream).orElse(null);
         System.setProperty("user.dir", userDir);
         Assert.assertNull(scanTomlFile);
-        String expected = getExpectedOutput("scan-toml-invalid-platform-jar.txt");
+        String expected = getExpectedOutput("scan-toml-invalid-platform-jar.txt")
+                .replace("<ABS_SOURCE_ROOT>", ballerinaProject.toAbsolutePath().toString());
         Assert.assertEquals(readOutput(true).trim(), expected);
     }
 
@@ -184,8 +185,10 @@ public class ScanUtilsTest extends BaseTest {
         ScanTomlFile scanTomlFile = ScanUtils.loadScanTomlConfigurations(project, printStream).orElse(null);
         System.setProperty("user.dir", userDir);
         Assert.assertNull(scanTomlFile);
-        String expected = getExpectedOutput("scan-toml-invalid-platform-config.txt");
-        Assert.assertEquals(readOutput(true).trim(), expected);
+        String expected = getExpectedOutput("scan-toml-invalid-platform-config.txt")
+                .replace("<ABS_SOURCE_ROOT>", ballerinaProject.toAbsolutePath().toString());
+        String actual = readOutput(true).trim();
+        Assert.assertEquals(actual, expected);
     }
 
     @Test(description =
@@ -254,7 +257,7 @@ public class ScanUtilsTest extends BaseTest {
     }
 
     @Test(description = "test method for loading configurations from a remote configuration file")
-    void testloadRemoteScanTomlConfigurations() {
+    void testLoadRemoteScanTomlConfigurations() {
         Path ballerinaProject = testResources.resolve("test-resources")
                 .resolve("bal-project-with-remote-config-file");
         Project project = ProjectLoader.load(ballerinaProject).project();
@@ -292,7 +295,7 @@ public class ScanUtilsTest extends BaseTest {
     }
 
     @Test(description = "test method for loading configurations from an invalid remote configuration file")
-    void testloadInvalidRemoteScanTomlConfigurations() throws IOException {
+    void testLoadInvalidRemoteScanTomlConfigurations() throws IOException {
         Path ballerinaProject = testResources.resolve("test-resources")
                 .resolve("bal-project-with-invalid-remote-config-file");
         Project project = ProjectLoader.load(ballerinaProject).project();

--- a/scan-command/src/test/java/io/ballerina/scan/utils/ScanUtilsTest.java
+++ b/scan-command/src/test/java/io/ballerina/scan/utils/ScanUtilsTest.java
@@ -19,9 +19,7 @@
 package io.ballerina.scan.utils;
 
 import io.ballerina.projects.Project;
-import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.directory.ProjectLoader;
-import io.ballerina.projects.directory.SingleFileProject;
 import io.ballerina.projects.util.ProjectUtils;
 import io.ballerina.scan.BaseTest;
 import io.ballerina.scan.Issue;
@@ -70,7 +68,7 @@ public class ScanUtilsTest extends BaseTest {
     @Test(description = "test method for saving results to file when no directory is provided")
     void testSaveToDirectory() throws IOException {
         List<Issue> issues = new ArrayList<>();
-        Project project = ProjectLoader.loadProject(validBalProject);
+        Project project = ProjectLoader.load(validBalProject).project();
         Path resultsFile = ScanUtils.saveToDirectory(issues, project, null);
         String result = Files.readString(resultsFile, StandardCharsets.UTF_8)
                 .replace(WINDOWS_LINE_SEPARATOR, LINUX_LINE_SEPARATOR);
@@ -81,7 +79,7 @@ public class ScanUtilsTest extends BaseTest {
     @Test(description = "test method for saving results to file when directory is provided")
     void testSaveToProvidedDirectory() throws IOException {
         List<Issue> issues = new ArrayList<>();
-        Project project = ProjectLoader.loadProject(validBalProject);
+        Project project = ProjectLoader.load(validBalProject).project();
         Path resultsFile = ScanUtils.saveToDirectory(issues, project, RESULTS_DIRECTORY);
         String result = Files.readString(resultsFile, StandardCharsets.UTF_8)
                 .replace(WINDOWS_LINE_SEPARATOR, LINUX_LINE_SEPARATOR);
@@ -92,7 +90,7 @@ public class ScanUtilsTest extends BaseTest {
     @Test(description = "test method for creating html analysis report from analysis results")
     void testGenerateScanReport() throws IOException {
         List<Issue> issues = new ArrayList<>();
-        Project project = ProjectLoader.loadProject(validBalProject);
+        Project project = ProjectLoader.load(validBalProject).project();
         Path scanReportPath = ScanUtils.generateScanReport(issues, project, null);
         String result = Files.readString(scanReportPath, StandardCharsets.UTF_8)
                 .replace(WINDOWS_LINE_SEPARATOR, LINUX_LINE_SEPARATOR);
@@ -104,7 +102,7 @@ public class ScanUtilsTest extends BaseTest {
             "test method for creating html analysis report from analysis results when directory is provided")
     void testGenerateScanReportToProvidedDirectory() throws IOException {
         List<Issue> issues = new ArrayList<>();
-        Project project = ProjectLoader.loadProject(validBalProject);
+        Project project = ProjectLoader.load(validBalProject).project();
         Path scanReportPath = ScanUtils.generateScanReport(issues, project, RESULTS_DIRECTORY);
         String result = Files.readString(scanReportPath, StandardCharsets.UTF_8)
                 .replace(WINDOWS_LINE_SEPARATOR, LINUX_LINE_SEPARATOR);
@@ -117,7 +115,7 @@ public class ScanUtilsTest extends BaseTest {
     void testloadScanTomlConfigurationsForSingleFileProject() {
         Path ballerinaProject = testResources.resolve("test-resources")
                 .resolve("single-file-project-with-config-file").resolve("main.bal");
-        Project project = SingleFileProject.load(ballerinaProject);
+        Project project = ProjectLoader.load(ballerinaProject).project();
         System.setProperty("user.dir", ballerinaProject.toString());
         ScanTomlFile scanTomlFile = ScanUtils.loadScanTomlConfigurations(project, printStream).orElse(null);
         System.setProperty("user.dir", userDir);
@@ -128,7 +126,7 @@ public class ScanUtilsTest extends BaseTest {
     void testloadScanTomlConfigurations() {
         Path ballerinaProject = testResources.resolve("test-resources")
                 .resolve("bal-project-with-config-file");
-        Project project = BuildProject.load(ballerinaProject);
+        Project project = ProjectLoader.load(ballerinaProject).project();
         System.setProperty("user.dir", ballerinaProject.toString());
         ScanTomlFile scanTomlFile = ScanUtils.loadScanTomlConfigurations(project, printStream).orElse(null);
         System.setProperty("user.dir", userDir);
@@ -167,7 +165,7 @@ public class ScanUtilsTest extends BaseTest {
     void testloadInvalidPlatformJAR() throws IOException {
         Path ballerinaProject = testResources.resolve("test-resources")
                 .resolve("bal-project-with-invalid-platform-jar");
-        Project project = BuildProject.load(ballerinaProject);
+        Project project = ProjectLoader.load(ballerinaProject).project();
         System.setProperty("user.dir", ballerinaProject.toString());
         ScanTomlFile scanTomlFile = ScanUtils.loadScanTomlConfigurations(project, printStream).orElse(null);
         System.setProperty("user.dir", userDir);
@@ -181,7 +179,7 @@ public class ScanUtilsTest extends BaseTest {
     void testloadInvalidPlatformScanTomlConfigurations() throws IOException {
         Path ballerinaProject = testResources.resolve("test-resources")
                 .resolve("bal-project-with-invalid-platform-config-file");
-        Project project = BuildProject.load(ballerinaProject);
+        Project project = ProjectLoader.load(ballerinaProject).project();
         System.setProperty("user.dir", ballerinaProject.toString());
         ScanTomlFile scanTomlFile = ScanUtils.loadScanTomlConfigurations(project, printStream).orElse(null);
         System.setProperty("user.dir", userDir);
@@ -195,7 +193,7 @@ public class ScanUtilsTest extends BaseTest {
     void testloadScanTomlConfigurationsWithInvalidBallerinaTomlConfiguration() throws IOException {
         Path ballerinaProject = testResources.resolve("test-resources")
                 .resolve("bal-project-with-invalid-file-configuration");
-        Project project = BuildProject.load(ballerinaProject);
+        Project project = ProjectLoader.load(ballerinaProject).project();
         System.setProperty("user.dir", ballerinaProject.toString());
         ScanTomlFile scanTomlFile = ScanUtils.loadScanTomlConfigurations(project, printStream).orElse(null);
         System.setProperty("user.dir", userDir);
@@ -208,7 +206,7 @@ public class ScanUtilsTest extends BaseTest {
     void testloadExternalScanTomlConfigurations() {
         Path ballerinaProject = testResources.resolve("test-resources")
                 .resolve("bal-project-with-external-config-file");
-        Project project = BuildProject.load(ballerinaProject);
+        Project project = ProjectLoader.load(ballerinaProject).project();
         System.setProperty("user.dir", ballerinaProject.toString());
         ScanTomlFile scanTomlFile = ScanUtils.loadScanTomlConfigurations(project, printStream).orElse(null);
         System.setProperty("user.dir", userDir);
@@ -246,7 +244,7 @@ public class ScanUtilsTest extends BaseTest {
     void testloadInvalidExternalScanTomlConfigurations() throws IOException {
         Path ballerinaProject = testResources.resolve("test-resources")
                 .resolve("bal-project-with-invalid-external-config-file");
-        Project project = BuildProject.load(ballerinaProject);
+        Project project = ProjectLoader.load(ballerinaProject).project();
         System.setProperty("user.dir", ballerinaProject.toString());
         ScanTomlFile scanTomlFile = ScanUtils.loadScanTomlConfigurations(project, printStream).orElse(null);
         System.setProperty("user.dir", userDir);
@@ -259,7 +257,7 @@ public class ScanUtilsTest extends BaseTest {
     void testloadRemoteScanTomlConfigurations() {
         Path ballerinaProject = testResources.resolve("test-resources")
                 .resolve("bal-project-with-remote-config-file");
-        Project project = BuildProject.load(ballerinaProject);
+        Project project = ProjectLoader.load(ballerinaProject).project();
         System.setProperty("user.dir", ballerinaProject.toString());
         ScanTomlFile scanTomlFile = ScanUtils.loadScanTomlConfigurations(project, printStream).orElse(null);
         System.setProperty("user.dir", userDir);
@@ -297,7 +295,7 @@ public class ScanUtilsTest extends BaseTest {
     void testloadInvalidRemoteScanTomlConfigurations() throws IOException {
         Path ballerinaProject = testResources.resolve("test-resources")
                 .resolve("bal-project-with-invalid-remote-config-file");
-        Project project = BuildProject.load(ballerinaProject);
+        Project project = ProjectLoader.load(ballerinaProject).project();
         System.setProperty("user.dir", ballerinaProject.toString());
         ScanTomlFile scanTomlFile = ScanUtils.loadScanTomlConfigurations(project, printStream).orElse(null);
         System.setProperty("user.dir", userDir);

--- a/scan-command/src/test/resources/command-outputs/unix/exclude-rules-issues-report.txt
+++ b/scan-command/src/test/resources/command-outputs/unix/exclude-rules-issues-report.txt
@@ -16,7 +16,7 @@
       "ruleKind": "CODE_SMELL"
     },
     "source": "BUILT_IN",
-    "fileName": "bal_project_with_analyzer_configurations/main.bal",
+    "fileName": "main.bal",
     "filePath": "<ABS_SOURCE_ROOT>/main.bal"
   },
   {
@@ -36,7 +36,7 @@
       "ruleKind": "CODE_SMELL"
     },
     "source": "EXTERNAL",
-    "fileName": "bal_project_with_analyzer_configurations/main.bal",
+    "fileName": "main.bal",
     "filePath": "<ABS_SOURCE_ROOT>/main.bal"
   },
   {
@@ -56,7 +56,7 @@
       "ruleKind": "CODE_SMELL"
     },
     "source": "BUILT_IN",
-    "fileName": "bal_project_with_analyzer_configurations/main.bal",
+    "fileName": "main.bal",
     "filePath": "<ABS_SOURCE_ROOT>/main.bal"
   }
 ]

--- a/scan-command/src/test/resources/command-outputs/unix/exclude-rules-issues-report.txt
+++ b/scan-command/src/test/resources/command-outputs/unix/exclude-rules-issues-report.txt
@@ -17,7 +17,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "bal_project_with_analyzer_configurations/main.bal",
-    "filePath": "src/test/resources/test-resources/bal-project-with-analyzer-configurations/main.bal"
+    "filePath": "<ABS_SOURCE_ROOT>/main.bal"
   },
   {
     "location": {
@@ -37,7 +37,7 @@
     },
     "source": "EXTERNAL",
     "fileName": "bal_project_with_analyzer_configurations/main.bal",
-    "filePath": "src/test/resources/test-resources/bal-project-with-analyzer-configurations/main.bal"
+    "filePath": "<ABS_SOURCE_ROOT>/main.bal"
   },
   {
     "location": {
@@ -57,6 +57,6 @@
     },
     "source": "BUILT_IN",
     "fileName": "bal_project_with_analyzer_configurations/main.bal",
-    "filePath": "src/test/resources/test-resources/bal-project-with-analyzer-configurations/main.bal"
+    "filePath": "<ABS_SOURCE_ROOT>/main.bal"
   }
 ]

--- a/scan-command/src/test/resources/command-outputs/unix/include-exclude-rules.txt
+++ b/scan-command/src/test/resources/command-outputs/unix/include-exclude-rules.txt
@@ -1,4 +1,4 @@
-Loading scan tool configurations from src/test/resources/test-resources/bal-project-with-analyzer-configurations/Scan.toml
+Loading scan tool configurations from <ABS_SOURCE_ROOT>/Scan.toml
 
 Running Scans
 cannot include and exclude rules at the same time

--- a/scan-command/src/test/resources/command-outputs/unix/include-rules-issues-report.txt
+++ b/scan-command/src/test/resources/command-outputs/unix/include-rules-issues-report.txt
@@ -17,6 +17,6 @@
     },
     "source": "BUILT_IN",
     "fileName": "bal_project_with_analyzer_configurations/main.bal",
-    "filePath": "src/test/resources/test-resources/bal-project-with-analyzer-configurations/main.bal"
+    "filePath": "<ABS_SOURCE_ROOT>/main.bal"
   }
 ]

--- a/scan-command/src/test/resources/command-outputs/unix/include-rules-issues-report.txt
+++ b/scan-command/src/test/resources/command-outputs/unix/include-rules-issues-report.txt
@@ -16,7 +16,7 @@
       "ruleKind": "CODE_SMELL"
     },
     "source": "BUILT_IN",
-    "fileName": "bal_project_with_analyzer_configurations/main.bal",
+    "fileName": "main.bal",
     "filePath": "<ABS_SOURCE_ROOT>/main.bal"
   }
 ]

--- a/scan-command/src/test/resources/command-outputs/unix/invalid-platform-plugin-configurations.txt
+++ b/scan-command/src/test/resources/command-outputs/unix/invalid-platform-plugin-configurations.txt
@@ -1,4 +1,4 @@
-Loading scan tool configurations from src/test/resources/test-resources/bal-project-with-invalid-platform-configurations/Scan.toml
+Loading scan tool configurations from <ABS_SOURCE_ROOT>/Scan.toml
 
 Running Scans
 

--- a/scan-command/src/test/resources/command-outputs/unix/list-rules-output.txt
+++ b/scan-command/src/test/resources/command-outputs/unix/list-rules-output.txt
@@ -1,4 +1,4 @@
-Loading scan tool configurations from src/test/resources/test-resources/bal-project-with-config-file/Scan.toml
+Loading scan tool configurations from <ABS_SOURCE_ROOT>/Scan.toml
 
 Running Scans
 	RuleID                                           | Rule Kind     | Rule Description                                 

--- a/scan-command/src/test/resources/command-outputs/unix/platform-plugin-issue-output.txt
+++ b/scan-command/src/test/resources/command-outputs/unix/platform-plugin-issue-output.txt
@@ -16,7 +16,7 @@
       "ruleKind": "CODE_SMELL"
     },
     "source": "BUILT_IN",
-    "fileName": "bal_project_with_platform_configurations/main.bal",
+    "fileName": "main.bal",
     "filePath": "<ABS_SOURCE_ROOT>/main.bal"
   }
 ]

--- a/scan-command/src/test/resources/command-outputs/unix/platform-plugin-issue-output.txt
+++ b/scan-command/src/test/resources/command-outputs/unix/platform-plugin-issue-output.txt
@@ -17,6 +17,6 @@
     },
     "source": "BUILT_IN",
     "fileName": "bal_project_with_platform_configurations/main.bal",
-    "filePath": "src/test/resources/test-resources/bal-project-with-platform-configurations/main.bal"
+    "filePath": "<ABS_SOURCE_ROOT>/main.bal"
   }
 ]

--- a/scan-command/src/test/resources/command-outputs/unix/print-rules-to-console.txt
+++ b/scan-command/src/test/resources/command-outputs/unix/print-rules-to-console.txt
@@ -1,4 +1,4 @@
-Loading scan tool configurations from src/test/resources/test-resources/bal-project-with-config-file/Scan.toml
+Loading scan tool configurations from <ABS_SOURCE_ROOT>/Scan.toml
 	RuleID                                           | Rule Kind     | Rule Description                                 
 	---------------------------------------------------------------------------------------------------------------------
 	ballerina:1                                      | CODE_SMELL    | Avoid checkpanic

--- a/scan-command/src/test/resources/command-outputs/unix/scan-toml-invalid-platform-config.txt
+++ b/scan-command/src/test/resources/command-outputs/unix/scan-toml-invalid-platform-config.txt
@@ -1,2 +1,2 @@
-Loading scan tool configurations from src/test/resources/test-resources/bal-project-with-invalid-platform-config-file/Scan.toml
+Loading scan tool configurations from <ABS_SOURCE_ROOT>/Scan.toml
 failed to retrieve remote platform file: no protocol: www.example.com/example-platform-analyzer-1.0.jar

--- a/scan-command/src/test/resources/command-outputs/unix/scan-toml-invalid-platform-jar.txt
+++ b/scan-command/src/test/resources/command-outputs/unix/scan-toml-invalid-platform-jar.txt
@@ -1,2 +1,2 @@
-Loading scan tool configurations from src/test/resources/test-resources/bal-project-with-invalid-platform-jar/Scan.toml
+Loading scan tool configurations from <ABS_SOURCE_ROOT>/Scan.toml
 failed to download remote jar file: 'examplePlatform.jar'

--- a/scan-command/src/test/resources/command-outputs/unix/toml-exclude-rules-issues-report.txt
+++ b/scan-command/src/test/resources/command-outputs/unix/toml-exclude-rules-issues-report.txt
@@ -16,7 +16,7 @@
       "ruleKind": "CODE_SMELL"
     },
     "source": "BUILT_IN",
-    "fileName": "bal_project_with_exclude_rule_configurations/main.bal",
+    "fileName": "main.bal",
     "filePath": "<ABS_SOURCE_ROOT>/main.bal"
   },
   {
@@ -36,7 +36,7 @@
       "ruleKind": "CODE_SMELL"
     },
     "source": "EXTERNAL",
-    "fileName": "bal_project_with_exclude_rule_configurations/main.bal",
+    "fileName": "main.bal",
     "filePath": "<ABS_SOURCE_ROOT>/main.bal"
   },
   {
@@ -56,7 +56,7 @@
       "ruleKind": "CODE_SMELL"
     },
     "source": "BUILT_IN",
-    "fileName": "bal_project_with_exclude_rule_configurations/main.bal",
+    "fileName": "main.bal",
     "filePath": "<ABS_SOURCE_ROOT>/main.bal"
   }
 ]

--- a/scan-command/src/test/resources/command-outputs/unix/toml-exclude-rules-issues-report.txt
+++ b/scan-command/src/test/resources/command-outputs/unix/toml-exclude-rules-issues-report.txt
@@ -17,7 +17,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "bal_project_with_exclude_rule_configurations/main.bal",
-    "filePath": "src/test/resources/test-resources/bal-project-with-exclude-rule-configurations/main.bal"
+    "filePath": "<ABS_SOURCE_ROOT>/main.bal"
   },
   {
     "location": {
@@ -37,7 +37,7 @@
     },
     "source": "EXTERNAL",
     "fileName": "bal_project_with_exclude_rule_configurations/main.bal",
-    "filePath": "src/test/resources/test-resources/bal-project-with-exclude-rule-configurations/main.bal"
+    "filePath": "<ABS_SOURCE_ROOT>/main.bal"
   },
   {
     "location": {
@@ -57,6 +57,6 @@
     },
     "source": "BUILT_IN",
     "fileName": "bal_project_with_exclude_rule_configurations/main.bal",
-    "filePath": "src/test/resources/test-resources/bal-project-with-exclude-rule-configurations/main.bal"
+    "filePath": "<ABS_SOURCE_ROOT>/main.bal"
   }
 ]

--- a/scan-command/src/test/resources/command-outputs/unix/toml-include-exclude-rules.txt
+++ b/scan-command/src/test/resources/command-outputs/unix/toml-include-exclude-rules.txt
@@ -1,4 +1,4 @@
-Loading scan tool configurations from src/test/resources/test-resources/bal-project-with-include-exclude-rule-configurations/Scan.toml
+Loading scan tool configurations from <ABS_SOURCE_ROOT>/Scan.toml
 
 Running Scans
 cannot include and exclude rules at the same time

--- a/scan-command/src/test/resources/command-outputs/unix/toml-include-rules-issues-report.txt
+++ b/scan-command/src/test/resources/command-outputs/unix/toml-include-rules-issues-report.txt
@@ -16,7 +16,7 @@
       "ruleKind": "CODE_SMELL"
     },
     "source": "BUILT_IN",
-    "fileName": "bal_project_with_include_rule_configurations/main.bal",
+    "fileName": "main.bal",
     "filePath": "<ABS_SOURCE_ROOT>/main.bal"
   }
 ]

--- a/scan-command/src/test/resources/command-outputs/unix/toml-include-rules-issues-report.txt
+++ b/scan-command/src/test/resources/command-outputs/unix/toml-include-rules-issues-report.txt
@@ -17,6 +17,6 @@
     },
     "source": "BUILT_IN",
     "fileName": "bal_project_with_include_rule_configurations/main.bal",
-    "filePath": "src/test/resources/test-resources/bal-project-with-include-rule-configurations/main.bal"
+    "filePath": "<ABS_SOURCE_ROOT>/main.bal"
   }
 ]

--- a/scan-command/src/test/resources/command-outputs/unix/workspace-issues.txt
+++ b/scan-command/src/test/resources/command-outputs/unix/workspace-issues.txt
@@ -1,0 +1,42 @@
+[
+  {
+    "location": {
+      "filePath": "main.bal",
+      "startLine": 20,
+      "endLine": 20,
+      "startColumn": 17,
+      "endColumn": 39,
+      "startOffset": 757,
+      "length": 22
+    },
+    "rule": {
+      "id": "ballerina:1",
+      "numericId": 1,
+      "description": "Avoid checkpanic",
+      "ruleKind": "CODE_SMELL"
+    },
+    "source": "BUILT_IN",
+    "fileName": "bal_project_with_analyzer_configurations/main.bal",
+    "filePath": "/Users/asmaj/ballerina/static-code-analysis-tool/scan-command/src/test/resources/test-resources/workspace-project/bal-project-with-analyzer-configurations/main.bal"
+  },
+  {
+    "location": {
+      "filePath": "main.bal",
+      "startLine": 20,
+      "endLine": 20,
+      "startColumn": 17,
+      "endColumn": 39,
+      "startOffset": 757,
+      "length": 22
+    },
+    "rule": {
+      "id": "ballerina:1",
+      "numericId": 1,
+      "description": "Avoid checkpanic",
+      "ruleKind": "CODE_SMELL"
+    },
+    "source": "BUILT_IN",
+    "fileName": "bal_project_with_include_rule_configurations/main.bal",
+    "filePath": "/Users/asmaj/ballerina/static-code-analysis-tool/scan-command/src/test/resources/test-resources/workspace-project/bal-project-with-include-rule-configurations/main.bal"
+  }
+]

--- a/scan-command/src/test/resources/command-outputs/windows/exclude-rules-issues-report.txt
+++ b/scan-command/src/test/resources/command-outputs/windows/exclude-rules-issues-report.txt
@@ -16,7 +16,7 @@
       "ruleKind": "CODE_SMELL"
     },
     "source": "BUILT_IN",
-    "fileName": "bal_project_with_analyzer_configurations/main.bal",
+    "fileName": "main.bal",
     "filePath": "<ABS_SOURCE_ROOT>\\main.bal"
   },
   {
@@ -36,7 +36,7 @@
       "ruleKind": "CODE_SMELL"
     },
     "source": "EXTERNAL",
-    "fileName": "bal_project_with_analyzer_configurations/main.bal",
+    "fileName": "main.bal",
     "filePath": "<ABS_SOURCE_ROOT>\\main.bal"
   },
   {
@@ -56,7 +56,7 @@
       "ruleKind": "CODE_SMELL"
     },
     "source": "BUILT_IN",
-    "fileName": "bal_project_with_analyzer_configurations/main.bal",
+    "fileName": "main.bal",
     "filePath": "<ABS_SOURCE_ROOT>\\main.bal"
   }
 ]

--- a/scan-command/src/test/resources/command-outputs/windows/exclude-rules-issues-report.txt
+++ b/scan-command/src/test/resources/command-outputs/windows/exclude-rules-issues-report.txt
@@ -17,7 +17,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "bal_project_with_analyzer_configurations/main.bal",
-    "filePath": "src\\test\\resources\\test-resources\\bal-project-with-analyzer-configurations\\main.bal"
+    "filePath": "<ABS_SOURCE_ROOT>\\main.bal"
   },
   {
     "location": {
@@ -37,7 +37,7 @@
     },
     "source": "EXTERNAL",
     "fileName": "bal_project_with_analyzer_configurations/main.bal",
-    "filePath": "src\\test\\resources\\test-resources\\bal-project-with-analyzer-configurations\\main.bal"
+    "filePath": "<ABS_SOURCE_ROOT>\\main.bal"
   },
   {
     "location": {
@@ -57,6 +57,6 @@
     },
     "source": "BUILT_IN",
     "fileName": "bal_project_with_analyzer_configurations/main.bal",
-    "filePath": "src\\test\\resources\\test-resources\\bal-project-with-analyzer-configurations\\main.bal"
+    "filePath": "<ABS_SOURCE_ROOT>\\main.bal"
   }
 ]

--- a/scan-command/src/test/resources/command-outputs/windows/include-exclude-rules.txt
+++ b/scan-command/src/test/resources/command-outputs/windows/include-exclude-rules.txt
@@ -1,4 +1,4 @@
-Loading scan tool configurations from src\test\resources\test-resources\bal-project-with-analyzer-configurations\Scan.toml
+Loading scan tool configurations from <ABS_SOURCE_ROOT>\Scan.toml
 
 Running Scans
 cannot include and exclude rules at the same time

--- a/scan-command/src/test/resources/command-outputs/windows/include-rules-issues-report.txt
+++ b/scan-command/src/test/resources/command-outputs/windows/include-rules-issues-report.txt
@@ -17,6 +17,6 @@
     },
     "source": "BUILT_IN",
     "fileName": "bal_project_with_analyzer_configurations/main.bal",
-    "filePath": "src\\test\\resources\\test-resources\\bal-project-with-analyzer-configurations\\main.bal"
+    "filePath": "<ABS_SOURCE_ROOT>\\main.bal"
   }
 ]

--- a/scan-command/src/test/resources/command-outputs/windows/include-rules-issues-report.txt
+++ b/scan-command/src/test/resources/command-outputs/windows/include-rules-issues-report.txt
@@ -16,7 +16,7 @@
       "ruleKind": "CODE_SMELL"
     },
     "source": "BUILT_IN",
-    "fileName": "bal_project_with_analyzer_configurations/main.bal",
+    "fileName": "main.bal",
     "filePath": "<ABS_SOURCE_ROOT>\\main.bal"
   }
 ]

--- a/scan-command/src/test/resources/command-outputs/windows/invalid-platform-plugin-configurations.txt
+++ b/scan-command/src/test/resources/command-outputs/windows/invalid-platform-plugin-configurations.txt
@@ -1,4 +1,4 @@
-Loading scan tool configurations from src\test\resources\test-resources\bal-project-with-invalid-platform-configurations\Scan.toml
+Loading scan tool configurations from <ABS_SOURCE_ROOT>\Scan.toml
 
 Running Scans
 

--- a/scan-command/src/test/resources/command-outputs/windows/list-rules-output.txt
+++ b/scan-command/src/test/resources/command-outputs/windows/list-rules-output.txt
@@ -1,4 +1,4 @@
-Loading scan tool configurations from src\test\resources\test-resources\bal-project-with-config-file\Scan.toml
+Loading scan tool configurations from <ABS_SOURCE_ROOT>\Scan.toml
 
 Running Scans
 	RuleID                                           | Rule Kind     | Rule Description                                 

--- a/scan-command/src/test/resources/command-outputs/windows/platform-plugin-issue-output.txt
+++ b/scan-command/src/test/resources/command-outputs/windows/platform-plugin-issue-output.txt
@@ -17,6 +17,6 @@
     },
     "source": "BUILT_IN",
     "fileName": "bal_project_with_platform_configurations/main.bal",
-    "filePath": "src\\test\\resources\\test-resources\\bal-project-with-platform-configurations\\main.bal"
+    "filePath": "<ABS_SOURCE_ROOT>\\main.bal"
   }
 ]

--- a/scan-command/src/test/resources/command-outputs/windows/platform-plugin-issue-output.txt
+++ b/scan-command/src/test/resources/command-outputs/windows/platform-plugin-issue-output.txt
@@ -16,7 +16,7 @@
       "ruleKind": "CODE_SMELL"
     },
     "source": "BUILT_IN",
-    "fileName": "bal_project_with_platform_configurations/main.bal",
+    "fileName": "main.bal",
     "filePath": "<ABS_SOURCE_ROOT>\\main.bal"
   }
 ]

--- a/scan-command/src/test/resources/command-outputs/windows/print-rules-to-console.txt
+++ b/scan-command/src/test/resources/command-outputs/windows/print-rules-to-console.txt
@@ -1,4 +1,4 @@
-Loading scan tool configurations from src\test\resources\test-resources\bal-project-with-config-file\Scan.toml
+Loading scan tool configurations from <ABS_SOURCE_ROOT>\Scan.toml
 	RuleID                                           | Rule Kind     | Rule Description                                 
 	---------------------------------------------------------------------------------------------------------------------
 	ballerina:1                                      | CODE_SMELL    | Avoid checkpanic

--- a/scan-command/src/test/resources/command-outputs/windows/scan-toml-invalid-platform-config.txt
+++ b/scan-command/src/test/resources/command-outputs/windows/scan-toml-invalid-platform-config.txt
@@ -1,2 +1,2 @@
-Loading scan tool configurations from src\test\resources\test-resources\bal-project-with-invalid-platform-config-file\Scan.toml
+Loading scan tool configurations from <ABS_SOURCE_ROOT>\Scan.toml
 failed to retrieve remote platform file: no protocol: www.example.com/example-platform-analyzer-1.0.jar

--- a/scan-command/src/test/resources/command-outputs/windows/scan-toml-invalid-platform-jar.txt
+++ b/scan-command/src/test/resources/command-outputs/windows/scan-toml-invalid-platform-jar.txt
@@ -1,2 +1,2 @@
-Loading scan tool configurations from src\test\resources\test-resources\bal-project-with-invalid-platform-jar\Scan.toml
+Loading scan tool configurations from <ABS_SOURCE_ROOT>\Scan.toml
 failed to download remote jar file: 'examplePlatform.jar'

--- a/scan-command/src/test/resources/command-outputs/windows/toml-exclude-rules-issues-report.txt
+++ b/scan-command/src/test/resources/command-outputs/windows/toml-exclude-rules-issues-report.txt
@@ -17,7 +17,7 @@
     },
     "source": "BUILT_IN",
     "fileName": "bal_project_with_exclude_rule_configurations/main.bal",
-    "filePath": "src\\test\\resources\\test-resources\\bal-project-with-exclude-rule-configurations\\main.bal"
+    "filePath": "<ABS_SOURCE_ROOT>\\main.bal"
   },
   {
     "location": {
@@ -37,7 +37,7 @@
     },
     "source": "EXTERNAL",
     "fileName": "bal_project_with_exclude_rule_configurations/main.bal",
-    "filePath": "src\\test\\resources\\test-resources\\bal-project-with-exclude-rule-configurations\\main.bal"
+    "filePath": "<ABS_SOURCE_ROOT>\\main.bal"
   },
   {
     "location": {
@@ -57,6 +57,6 @@
     },
     "source": "BUILT_IN",
     "fileName": "bal_project_with_exclude_rule_configurations/main.bal",
-    "filePath": "src\\test\\resources\\test-resources\\bal-project-with-exclude-rule-configurations\\main.bal"
+    "filePath": "<ABS_SOURCE_ROOT>\\main.bal"
   }
 ]

--- a/scan-command/src/test/resources/command-outputs/windows/toml-exclude-rules-issues-report.txt
+++ b/scan-command/src/test/resources/command-outputs/windows/toml-exclude-rules-issues-report.txt
@@ -16,7 +16,7 @@
       "ruleKind": "CODE_SMELL"
     },
     "source": "BUILT_IN",
-    "fileName": "bal_project_with_exclude_rule_configurations/main.bal",
+    "fileName": "main.bal",
     "filePath": "<ABS_SOURCE_ROOT>\\main.bal"
   },
   {
@@ -36,7 +36,7 @@
       "ruleKind": "CODE_SMELL"
     },
     "source": "EXTERNAL",
-    "fileName": "bal_project_with_exclude_rule_configurations/main.bal",
+    "fileName": "main.bal",
     "filePath": "<ABS_SOURCE_ROOT>\\main.bal"
   },
   {
@@ -56,7 +56,7 @@
       "ruleKind": "CODE_SMELL"
     },
     "source": "BUILT_IN",
-    "fileName": "bal_project_with_exclude_rule_configurations/main.bal",
+    "fileName": "main.bal",
     "filePath": "<ABS_SOURCE_ROOT>\\main.bal"
   }
 ]

--- a/scan-command/src/test/resources/command-outputs/windows/toml-include-exclude-rules.txt
+++ b/scan-command/src/test/resources/command-outputs/windows/toml-include-exclude-rules.txt
@@ -1,4 +1,4 @@
-Loading scan tool configurations from src\test\resources\test-resources\bal-project-with-include-exclude-rule-configurations\Scan.toml
+Loading scan tool configurations from <ABS_SOURCE_ROOT>\Scan.toml
 
 Running Scans
 cannot include and exclude rules at the same time

--- a/scan-command/src/test/resources/command-outputs/windows/toml-include-rules-issues-report.txt
+++ b/scan-command/src/test/resources/command-outputs/windows/toml-include-rules-issues-report.txt
@@ -16,7 +16,7 @@
       "ruleKind": "CODE_SMELL"
     },
     "source": "BUILT_IN",
-    "fileName": "bal_project_with_include_rule_configurations/main.bal",
+    "fileName": "main.bal",
     "filePath": "<ABS_SOURCE_ROOT>\\main.bal"
   }
 ]

--- a/scan-command/src/test/resources/command-outputs/windows/toml-include-rules-issues-report.txt
+++ b/scan-command/src/test/resources/command-outputs/windows/toml-include-rules-issues-report.txt
@@ -17,6 +17,6 @@
     },
     "source": "BUILT_IN",
     "fileName": "bal_project_with_include_rule_configurations/main.bal",
-    "filePath": "src\\test\\resources\\test-resources\\bal-project-with-include-rule-configurations\\main.bal"
+    "filePath": "<ABS_SOURCE_ROOT>\\main.bal"
   }
 ]

--- a/scan-command/src/test/resources/command-outputs/windows/workspace-issues.txt
+++ b/scan-command/src/test/resources/command-outputs/windows/workspace-issues.txt
@@ -6,7 +6,7 @@
       "endLine": 20,
       "startColumn": 17,
       "endColumn": 39,
-      "startOffset": 757,
+      "startOffset": 777,
       "length": 22
     },
     "rule": {
@@ -16,8 +16,8 @@
       "ruleKind": "CODE_SMELL"
     },
     "source": "BUILT_IN",
-    "fileName": "bal_project_with_analyzer_configurations/main.bal",
-    "filePath": "<ABS_SOURCE_ROOT>/bal-project-with-analyzer-configurations/main.bal"
+    "fileName": "bal_project_with_analyzer_configurations\main.bal",
+    "filePath": "<ABS_SOURCE_ROOT>\\bal-project-with-analyzer-configurations\\main.bal"
   },
   {
     "location": {
@@ -26,7 +26,7 @@
       "endLine": 20,
       "startColumn": 17,
       "endColumn": 39,
-      "startOffset": 757,
+      "startOffset": 777,
       "length": 22
     },
     "rule": {
@@ -36,7 +36,7 @@
       "ruleKind": "CODE_SMELL"
     },
     "source": "BUILT_IN",
-    "fileName": "bal_project_with_include_rule_configurations/main.bal",
-    "filePath": "<ABS_SOURCE_ROOT>/bal-project-with-include-rule-configurations/main.bal"
+    "fileName": "bal_project_with_include_rule_configurations\main.bal",
+    "filePath": "<ABS_SOURCE_ROOT>\\bal-project-with-include-rule-configurations\\main.bal"
   }
 ]

--- a/scan-command/src/test/resources/test-resources/workspace-project/Ballerina.toml
+++ b/scan-command/src/test/resources/test-resources/workspace-project/Ballerina.toml
@@ -1,0 +1,2 @@
+[workspace]
+packages = ["bal-project-with-analyzer-configurations", "bal-project-with-include-rule-configurations"]

--- a/scan-command/src/test/resources/test-resources/workspace-project/bal-project-with-analyzer-configurations/.gitignore
+++ b/scan-command/src/test/resources/test-resources/workspace-project/bal-project-with-analyzer-configurations/.gitignore
@@ -1,0 +1,4 @@
+target
+generated
+Config.toml
+Dependencies.toml

--- a/scan-command/src/test/resources/test-resources/workspace-project/bal-project-with-analyzer-configurations/Ballerina.toml
+++ b/scan-command/src/test/resources/test-resources/workspace-project/bal-project-with-analyzer-configurations/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "ballerina"
+name = "bal_project_with_analyzer_configurations"
+version = "0.1.0"

--- a/scan-command/src/test/resources/test-resources/workspace-project/bal-project-with-analyzer-configurations/Scan.toml
+++ b/scan-command/src/test/resources/test-resources/workspace-project/bal-project-with-analyzer-configurations/Scan.toml
@@ -1,0 +1,15 @@
+# custom compiler plugins
+[[analyzer]]
+org = "exampleOrg"
+name = "example_module_static_code_analyzer"
+
+[[analyzer]]
+org = "ballerina"
+name = "example_module_static_code_analyzer"
+version = "0.1.0"
+
+[[analyzer]]
+org = "ballerinax"
+name = "example_module_static_code_analyzer"
+version = "0.1.0"
+repository = "local"

--- a/scan-command/src/test/resources/test-resources/workspace-project/bal-project-with-analyzer-configurations/main.bal
+++ b/scan-command/src/test/resources/test-resources/workspace-project/bal-project-with-analyzer-configurations/main.bal
@@ -1,0 +1,22 @@
+// Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function getResult() returns int|error => 1;
+
+public function main() {
+    // Non-compliant
+    int result = checkpanic getResult();
+}

--- a/scan-command/src/test/resources/test-resources/workspace-project/bal-project-with-analyzer-configurations/main.bal
+++ b/scan-command/src/test/resources/test-resources/workspace-project/bal-project-with-analyzer-configurations/main.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/scan-command/src/test/resources/test-resources/workspace-project/bal-project-with-include-rule-configurations/.gitignore
+++ b/scan-command/src/test/resources/test-resources/workspace-project/bal-project-with-include-rule-configurations/.gitignore
@@ -1,0 +1,4 @@
+target
+generated
+Config.toml
+Dependencies.toml

--- a/scan-command/src/test/resources/test-resources/workspace-project/bal-project-with-include-rule-configurations/Ballerina.toml
+++ b/scan-command/src/test/resources/test-resources/workspace-project/bal-project-with-include-rule-configurations/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "ballerina"
+name = "bal_project_with_include_rule_configurations"
+version = "0.1.0"

--- a/scan-command/src/test/resources/test-resources/workspace-project/bal-project-with-include-rule-configurations/Scan.toml
+++ b/scan-command/src/test/resources/test-resources/workspace-project/bal-project-with-include-rule-configurations/Scan.toml
@@ -1,0 +1,20 @@
+# custom compiler plugins
+[[analyzer]]
+org = "exampleOrg"
+name = "example_module_static_code_analyzer"
+
+[[analyzer]]
+org = "ballerina"
+name = "example_module_static_code_analyzer"
+version = "0.1.0"
+
+[[analyzer]]
+org = "ballerinax"
+name = "example_module_static_code_analyzer"
+version = "0.1.0"
+repository = "local"
+
+[rule]
+include =[
+    "ballerina:1"
+]

--- a/scan-command/src/test/resources/test-resources/workspace-project/bal-project-with-include-rule-configurations/main.bal
+++ b/scan-command/src/test/resources/test-resources/workspace-project/bal-project-with-include-rule-configurations/main.bal
@@ -1,0 +1,22 @@
+// Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function getResult() returns int|error => 1;
+
+public function main() {
+    // Non-compliant
+    int result = checkpanic getResult();
+}

--- a/scan-command/src/test/resources/test-resources/workspace-project/bal-project-with-include-rule-configurations/main.bal
+++ b/scan-command/src/test/resources/test-resources/workspace-project/bal-project-with-include-rule-configurations/main.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, WSO2 LLC. (https://www.wso2.com).
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/scan-command/tool-scan/Ballerina.toml
+++ b/scan-command/tool-scan/Ballerina.toml
@@ -2,7 +2,7 @@
 org = "ballerina"
 name = "tool_scan"
 version = "0.11.1-SNAPSHOT"
-distribution = "2201.12.0"
+distribution = "2201.13.0"
 authors = ["Ballerina"]
 keywords = ["scan", "static code analysis"]
 license = ["Apache-2.0"]

--- a/scan-command/tool-scan/Ballerina.toml
+++ b/scan-command/tool-scan/Ballerina.toml
@@ -2,7 +2,7 @@
 org = "ballerina"
 name = "tool_scan"
 version = "0.11.1-SNAPSHOT"
-distribution = "2201.13.0"
+distribution = "2201.13.2"
 authors = ["Ballerina"]
 keywords = ["scan", "static code analysis"]
 license = ["Apache-2.0"]

--- a/scan-command/tool-scan/Dependencies.toml
+++ b/scan-command/tool-scan/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.13.0"
+distribution-version = "2201.13.1"
 
 [[package]]
 org = "ballerina"

--- a/scan-command/tool-scan/Dependencies.toml
+++ b/scan-command/tool-scan/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.13.1"
+distribution-version = "2201.13.2"
 
 [[package]]
 org = "ballerina"

--- a/scan-command/tool-scan/Dependencies.toml
+++ b/scan-command/tool-scan/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.9"
+distribution-version = "2201.13.0"
 
 [[package]]
 org = "ballerina"


### PR DESCRIPTION
## Purpose

> Resolves #78 

## Check List

- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Integration Tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR implements workspace-aware scanning so the scan command can be run from a Ballerina workspace root and produce a single aggregated report for the entire workspace, resolving issue #78 and aligning with workspace support introduced in Ballerina Update 13.

Key changes
- Workspace scanning
  - Detects workspace projects, resolves the workspace dependency graph, analyzes constituent projects in topological order, skips empty packages, and aggregates issues into a single JSON or SARIF report.
  - Centralizes per-project analysis via ScanCmd.executeProject(Project) and accumulates results across the workspace.

- Project loading and diagnostics
  - Consolidates project loading to ProjectLoader.load(...).project() with diagnostic validation, replacing prior branching between BuildProject.load() and SingleFileProject.load().
  - Applies the unified loader across production code and tests and surfaces load diagnostics for invalid inputs.

- Reporting and utilities
  - Produces workspace-targeted report output and updates SARIF numeric serialization and JSON path handling on Windows.
  - Expands visibility of several helper methods and result filename constants to support cross-package usage.
  - Resolves local Scan.toml relative to each project’s source root.

- Tests and test resources
  - Adds workspace test fixtures (multi-package workspace with per-package Scan.toml and sources) and expected workspace JSON/SARIF outputs.
  - Updates many test fixtures to use absolute-path placeholders and switches tests to use ProjectLoader.load(...).project().

- Build, CI, and toolchain updates
  - Bumps Ballerina toolchain/configuration from 2201.12.0 to 2201.13.0 across CI workflows and build manifests.
  - Adjusts Gradle test task to obtain ballerina.home via the bal home command and clears BALLERINA_HOME in CI build steps.

Reviewer notes
- Review the API visibility changes (public constants and utility methods) for compatibility.
- Verify consolidated project-loading behavior and aggregated report generation.
- Ensure CI and local environments support Ballerina 2201.13.x; confirm tests covering workspace scenarios pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->