### PR TITLE
Enable Language Server to invoke scanner with local/global exclusions

### DIFF
--- a/scan-command/src/main/java/io/ballerina/scan/ExcludedIssue.java
+++ b/scan-command/src/main/java/io/ballerina/scan/ExcludedIssue.java
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.scan;
+
+/**
+ * Represents a security issue that has been excluded from the results.
+ *
+ * @since 0.11.1
+ */
+public class ExcludedIssue {
+    private final Issue issue;
+    private final String ruleId;
+    private final String filePath;
+    private final String symbol;
+    private final String lineHash;
+    private final boolean isGlobalExclusion;
+
+    public ExcludedIssue(Issue issue, String ruleId, String filePath, String symbol, String lineHash,
+                         boolean isGlobalExclusion) {
+        this.issue = issue;
+        this.ruleId = ruleId;
+        this.filePath = filePath;
+        this.symbol = symbol;
+        this.lineHash = lineHash;
+        this.isGlobalExclusion = isGlobalExclusion;
+    }
+
+    /**
+     * Returns the {@link Issue} that was excluded.
+     *
+     * @return the excluded issue
+     */
+    public Issue issue() {
+        return issue;
+    }
+
+    /**
+     * Returns the fully qualified rule identifier of the excluded issue.
+     *
+     * @return rule identifier
+     */
+    public String ruleId() {
+        return ruleId;
+    }
+
+    /**
+     * Returns the file path where the issue was found.
+     *
+     * @return file path
+     */
+    public String filePath() {
+        return filePath;
+    }
+
+    /**
+     * Returns the enclosing symbol name where the issue was found.
+     *
+     * @return symbol name
+     */
+    public String symbol() {
+        return symbol;
+    }
+
+    /**
+     * Returns the hash of the line content where the issue was found.
+     *
+     * @return line hash
+     */
+    public String lineHash() {
+        return lineHash;
+    }
+
+    /**
+     * Returns true if the issue was excluded due to a global rule exclusion.
+     *
+     * @return true if globally excluded
+     */
+    public boolean isGlobalExclusion() {
+        return isGlobalExclusion;
+    }
+}

--- a/scan-command/src/main/java/io/ballerina/scan/ScanResult.java
+++ b/scan-command/src/main/java/io/ballerina/scan/ScanResult.java
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.scan;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents the response of a security scan, containing both active and excluded issues.
+ *
+ * @since 0.11.1
+ */
+public class ScanResult {
+    private final List<Issue> activeIssues;
+    private final List<ExcludedIssue> excludedIssues;
+
+    public ScanResult(List<Issue> activeIssues, List<ExcludedIssue> excludedIssues) {
+        this.activeIssues = new ArrayList<>(activeIssues);
+        this.excludedIssues = new ArrayList<>(excludedIssues);
+    }
+
+    /**
+     * Returns the list of active security issues found.
+     *
+     * @return list of active issues
+     */
+    public List<Issue> activeIssues() {
+        return Collections.unmodifiableList(activeIssues);
+    }
+
+    /**
+     * Returns the list of security issues that were excluded based on Scan.toml configurations.
+     *
+     * @return list of excluded issues
+     */
+    public List<ExcludedIssue> excludedIssues() {
+        return Collections.unmodifiableList(excludedIssues);
+    }
+}

--- a/scan-command/src/main/java/io/ballerina/scan/internal/ScanCmd.java
+++ b/scan-command/src/main/java/io/ballerina/scan/internal/ScanCmd.java
@@ -35,6 +35,7 @@ import io.ballerina.scan.utils.DiagnosticLog;
 import io.ballerina.scan.utils.ScanTomlFile;
 import io.ballerina.scan.utils.ScanToolException;
 import io.ballerina.scan.utils.ScanUtils;
+import io.ballerina.scan.utils.SymbolResolver;
 import picocli.CommandLine;
 
 import java.io.BufferedReader;
@@ -56,6 +57,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.ServiceLoader;
+import java.util.Set;
 
 import static io.ballerina.scan.internal.ScanToolConstants.RUNNING_SCANS_LOG;
 import static io.ballerina.scan.internal.ScanToolConstants.SCAN_COMMAND;
@@ -245,6 +247,27 @@ public class ScanCmd implements BLauncherCmd {
         }
         if (!excludeRules.isEmpty()) {
             issues.removeIf(issue -> excludeRules.contains(issue.rule().id()));
+        }
+
+        // Apply symbol-based exclusions
+        Set<ScanTomlFile.Exclusion> exclusions = scanTomlFile.get().getExclusions();
+        if (!exclusions.isEmpty()) {
+            issues.removeIf(issue -> {
+                if (issue.location() == null || issue.location().lineRange() == null 
+                        || issue.location().lineRange().fileName() == null) {
+                    return false;
+                }
+                String issueFileName = issue.location().lineRange().fileName();
+                int issueLine = issue.location().lineRange().startLine().line();
+                String issueSymbol = SymbolResolver.resolveSymbol(project.get(), issueFileName, issueLine);
+                String issueLineHash = SymbolResolver.resolveLineHash(project.get(), issueFileName, issueLine);
+                return exclusions.stream().anyMatch(exclusion ->
+                        ScanUtils.matchesExclusion(issueFileName,
+                                                   issue.rule().id(),
+                                                   issueSymbol,
+                                                   issueLineHash,
+                                                   exclusion));
+            });
         }
 
         if (platforms.isEmpty() && !platformTriggered) {

--- a/scan-command/src/main/java/io/ballerina/scan/internal/ScanCmd.java
+++ b/scan-command/src/main/java/io/ballerina/scan/internal/ScanCmd.java
@@ -320,7 +320,8 @@ public class ScanCmd implements BLauncherCmd {
         if (!exclusions.isEmpty()) {
             issues.removeIf(issue -> {
                 if (issue.location() == null || issue.location().lineRange() == null 
-                        || issue.location().lineRange().fileName() == null) {
+                        || issue.location().lineRange().fileName() == null
+                        || issue.location().lineRange().startLine() == null) {
                     return false;
                 }
                 String issueFileName = issue.location().lineRange().fileName();

--- a/scan-command/src/main/java/io/ballerina/scan/internal/ScanTool.java
+++ b/scan-command/src/main/java/io/ballerina/scan/internal/ScanTool.java
@@ -28,6 +28,7 @@ import io.ballerina.scan.ExcludedIssue;
 import io.ballerina.scan.Issue;
 import io.ballerina.scan.Rule;
 import io.ballerina.scan.ScanResult;
+import io.ballerina.scan.utils.Constants;
 import io.ballerina.scan.utils.ScanTomlFile;
 import io.ballerina.scan.utils.ScanTomlWriter;
 import io.ballerina.scan.utils.ScanUtils;
@@ -63,29 +64,10 @@ public class ScanTool {
      * Returns a JSON string of issues.
      */
     public static String runScan(String projectPathStr,
-                                 Map<String, String> unsavedFileContent,
                                  Map<String, Boolean> buildOptionsMap) {
         try {
             Path projectPath = Paths.get(projectPathStr);
-
-            // Extract Build Options
-            boolean isOffline = buildOptionsMap != null && Boolean
-                    .TRUE.equals(buildOptionsMap.get("offline"));
-            boolean isSticky = buildOptionsMap != null && Boolean
-                    .TRUE.equals(buildOptionsMap.get("sticky"));
-            boolean isSkipTests = buildOptionsMap != null && Boolean
-                    .TRUE.equals(buildOptionsMap.get("skipTests"));
-            boolean isApplyUnsavedChanges = buildOptionsMap != null && Boolean
-                    .TRUE.equals(buildOptionsMap.get("applyUnsavedChanges"));
-
-            // Load Project from Disk with Options
-            BuildOptions buildOptions = BuildOptions.builder()
-                    .setOffline(isOffline)
-                    .setSticky(isSticky)
-                    .setSkipTests(isSkipTests)
-                    .build();
-
-            Project project = BuildProject.load(projectPath, buildOptions);
+            Project project = loadProjectForLs(projectPath, buildOptionsMap);
 
             // Run the scanner
             ScanResult result = runScan(project);
@@ -108,40 +90,23 @@ public class ScanTool {
 
     /**
      * ENTRY POINT FOR ADDING EXCLUSIONS
-     * Resolves the AST symbol at the given line and writes a symbol-based exclusion
-     * entry to the Scan.toml file.
+    * Resolves the AST symbol at the given line and writes a symbol-based exclusion
+    * entry to the Constants.SCAN_FILE file.
      */
     public static String addExclusion(String projectPathStr, String filePath, int lineNumber,
-                                      String ruleId, Map<String, String> unsavedFileContent,
+                                      String ruleId,
                                       Map<String, Boolean> buildOptionsMap) {
         JsonObject result = new JsonObject();
         try {
             Path projectPath = Paths.get(projectPathStr);
-
-            // Extract Build Options
-            boolean isOffline = buildOptionsMap != null && Boolean
-                    .TRUE.equals(buildOptionsMap.get("offline"));
-            boolean isSticky = buildOptionsMap != null && Boolean
-                    .TRUE.equals(buildOptionsMap.get("sticky"));
-            boolean isSkipTests = buildOptionsMap != null && Boolean
-                    .TRUE.equals(buildOptionsMap.get("skipTests"));
-            boolean isApplyUnsavedChanges = buildOptionsMap != null && Boolean
-                    .TRUE.equals(buildOptionsMap.get("applyUnsavedChanges"));
-
-            BuildOptions buildOptions = BuildOptions.builder()
-                    .setOffline(isOffline)
-                    .setSticky(isSticky)
-                    .setSkipTests(isSkipTests)
-                    .build();
-
-            Project project = BuildProject.load(projectPath, buildOptions);
+            Project project = loadProjectForLs(projectPath, buildOptionsMap);
 
             // Resolve the enclosing symbol and line hash
             String symbol = SymbolResolver.resolveSymbol(project, filePath, lineNumber);
             String lineHash = SymbolResolver.resolveLineHash(project, filePath, lineNumber);
 
-            // Write the exclusion to Scan.toml
-            Path scanTomlPath = projectPath.resolve("Scan.toml");
+            // Write the exclusion to Constants.SCAN_FILE
+            Path scanTomlPath = projectPath.resolve(Constants.SCAN_FILE);
             String relativeFilePath = ScanUtils.getRelativePath(filePath, project.sourceRoot().toString());
             ScanTomlWriter.addExclusion(scanTomlPath, relativeFilePath, ruleId, symbol, lineHash);
 
@@ -154,7 +119,8 @@ public class ScanTool {
                     + "' in file '" + filePath + "' for rule '" + ruleId + "'");
         } catch (IOException e) {
             result.addProperty("success", false);
-            result.addProperty("error", "Failed to write exclusion to Scan.toml: " + e.getMessage());
+                result.addProperty("error", "Failed to write exclusion to " + Constants.SCAN_FILE + ": "
+                    + e.getMessage());
         } catch (Exception e) {
             result.addProperty("success", false);
             result.addProperty("error", "Failed to add exclusion: " + e.getMessage());
@@ -163,14 +129,14 @@ public class ScanTool {
     }
 
     /**
-     * ENTRY POINT FOR ADDING GLOBAL EXCLUSIONS
-     * Adds a rule ID to the global `[rule]` section in Scan.toml.
+    * ENTRY POINT FOR ADDING GLOBAL EXCLUSIONS
+    * Adds a rule ID to the global `[rule]` section in Constants.SCAN_FILE.
      */
     public static String addGlobalExclusion(String projectPathStr, String ruleId) {
         JsonObject result = new JsonObject();
         try {
             Path projectPath = Paths.get(projectPathStr);
-            Path scanTomlPath = projectPath.resolve("Scan.toml");
+            Path scanTomlPath = projectPath.resolve(Constants.SCAN_FILE);
             ScanTomlWriter.addGlobalExclusion(scanTomlPath, ruleId);
 
             result.addProperty("success", true);
@@ -178,7 +144,8 @@ public class ScanTool {
             result.addProperty("message", "Global exclusion added successfully for rule '" + ruleId + "'");
         } catch (IOException e) {
             result.addProperty("success", false);
-            result.addProperty("error", "Failed to write global exclusion to Scan.toml: " + e.getMessage());
+                result.addProperty("error", "Failed to write global exclusion to " + Constants.SCAN_FILE + ": "
+                    + e.getMessage());
         } catch (Exception e) {
             result.addProperty("success", false);
             result.addProperty("error", "Failed to add global exclusion: " + e.getMessage());
@@ -187,8 +154,8 @@ public class ScanTool {
     }
 
     /**
-     * ENTRY POINT FOR REMOVING EXCLUSIONS
-     * Removes a symbol-based exclusion entry from the Scan.toml file.
+    * ENTRY POINT FOR REMOVING EXCLUSIONS
+    * Removes a symbol-based exclusion entry from the Constants.SCAN_FILE file.
      */
     public static String removeExclusion(String projectPathStr, String filePath,
                                          String ruleId, String symbol, String lineHash) {
@@ -198,7 +165,7 @@ public class ScanTool {
             Project project = BuildProject.load(projectPath, BuildOptions.builder().build());
             
             String relativeFilePath = ScanUtils.getRelativePath(filePath, project.sourceRoot().toString());
-            Path scanTomlPath = projectPath.resolve("Scan.toml");
+            Path scanTomlPath = projectPath.resolve(Constants.SCAN_FILE);
             ScanTomlWriter.removeExclusion(scanTomlPath, relativeFilePath, ruleId, symbol, lineHash);
 
             result.addProperty("success", true);
@@ -216,13 +183,13 @@ public class ScanTool {
     }
 
     /**
-     * ENTRY POINT FOR REMOVING GLOBAL EXCLUSIONS
-     * Removes a rule ID from the global `[rule]` section in Scan.toml.
+    * ENTRY POINT FOR REMOVING GLOBAL EXCLUSIONS
+    * Removes a rule ID from the global `[rule]` section in Constants.SCAN_FILE.
      */
     public static String removeGlobalExclusion(String projectPathStr, String ruleId) {
         JsonObject result = new JsonObject();
         try {
-            Path scanTomlPath = Paths.get(projectPathStr).resolve("Scan.toml");
+            Path scanTomlPath = Paths.get(projectPathStr).resolve(Constants.SCAN_FILE);
             ScanTomlWriter.removeGlobalExclusion(scanTomlPath, ruleId);
 
             result.addProperty("success", true);
@@ -242,13 +209,28 @@ public class ScanTool {
     // CORE SCANNING LOGIC
     // ===================================================================================
 
+    private static Project loadProjectForLs(Path projectPath, Map<String, Boolean> buildOptionsMap) {
+        boolean isOffline = buildOptionsMap != null && Boolean.TRUE.equals(buildOptionsMap.get("offline"));
+        boolean isSticky = buildOptionsMap != null && Boolean.TRUE.equals(buildOptionsMap.get("sticky"));
+        boolean isSkipTests = buildOptionsMap != null && Boolean.TRUE.equals(buildOptionsMap.get("skipTests"));
+
+        BuildOptions buildOptions = BuildOptions.builder()
+                .setOffline(isOffline)
+                .setSticky(isSticky)
+                .setSkipTests(isSkipTests)
+                .build();
+
+        return BuildProject.load(projectPath, buildOptions);
+    }
+
     private static ScanResult runScan(Project project) {
+        java.io.ByteArrayOutputStream diagnosticBuffer = new java.io.ByteArrayOutputStream();
         PrintStream silentStream = new PrintStream(
-                new java.io.ByteArrayOutputStream(),
+                diagnosticBuffer,
                 true,
                 StandardCharsets.UTF_8);
 
-        // Load Scan.toml configurations
+        // Load Constants.SCAN_FILE configurations
         Optional<ScanTomlFile> scanToml = ScanUtils.loadScanTomlConfigurations(project, silentStream);
         
         // If Scan.toml is malformed or missing, return a failing ScanResult
@@ -263,7 +245,7 @@ public class ScanTool {
     }
 
     /**
-     * Executes scanning with include/exclude filters resolved from Scan.toml.
+    * Executes scanning with include/exclude filters resolved from Constants.SCAN_FILE.
      *
      * @throws IllegalArgumentException when both include and exclude rule filters are configured,
      *                                  since they are mutually exclusive.
@@ -289,7 +271,8 @@ public class ScanTool {
         }
 
         if (!includeRules.isEmpty() && !excludeRules.isEmpty()) {
-            throw new IllegalArgumentException("Invalid Scan.toml configuration: both include and exclude rule "
+                throw new IllegalArgumentException("Invalid " + Constants.SCAN_FILE
+                    + " configuration: both include and exclude rule "
                     + "filters are set. Configure only one of [rule.include] or [rule.exclude].");
         }
 
@@ -324,23 +307,21 @@ public class ScanTool {
             }
 
             // Resolve context data for local exclusions whenever possible.
-            if (scanToml != null && project != null) {
-                Set<ScanTomlFile.Exclusion> exclusions = scanToml.getExclusions();
-                if (!exclusions.isEmpty()) {
-                    if (issue.location() != null && issue.location().lineRange() != null
-                            && issue.location().lineRange().fileName() != null
-                            && issue.location().lineRange().startLine() != null) {
-                        int issueLine = issue.location().lineRange().startLine().line();
-                        issueSymbol = SymbolResolver.resolveSymbol(project, issueFileName, issueLine);
-                        issueLineHash = SymbolResolver.resolveLineHash(project, issueFileName, issueLine);
+            Set<ScanTomlFile.Exclusion> exclusions = scanToml.getExclusions();
+            if (!exclusions.isEmpty()) {
+                if (issue.location() != null && issue.location().lineRange() != null
+                        && issue.location().lineRange().fileName() != null
+                        && issue.location().lineRange().startLine() != null) {
+                    int issueLine = issue.location().lineRange().startLine().line();
+                    issueSymbol = SymbolResolver.resolveSymbol(project, issueFileName, issueLine);
+                    issueLineHash = SymbolResolver.resolveLineHash(project, issueFileName, issueLine);
 
-                        String finalExSymbol = issueSymbol;
-                        String finalExLineHash = issueLineHash;
+                    String finalExSymbol = issueSymbol;
+                    String finalExLineHash = issueLineHash;
 
-                        isExcludedByLocal = exclusions.stream().anyMatch(exclusion ->
-                                ScanUtils.matchesExclusion(issueFileName, ruleId,
-                                        finalExSymbol, finalExLineHash, exclusion));
-                    }
+                    isExcludedByLocal = exclusions.stream().anyMatch(exclusion ->
+                            ScanUtils.matchesExclusion(issueFileName, ruleId,
+                                    finalExSymbol, finalExLineHash, exclusion));
                 }
             }
 
@@ -348,7 +329,7 @@ public class ScanTool {
             isGlobalExclusion = isExcludedByGlobal && !isExcludedByLocal;
 
             if (isExcluded) {
-                if (issueSymbol.isEmpty() && project != null && issue.location() != null
+                if (issueSymbol.isEmpty() && issue.location() != null
                         && issue.location().lineRange() != null
                         && issue.location().lineRange().startLine() != null) {
                     int issueLine = issue.location().lineRange().startLine().line();

--- a/scan-command/src/main/java/io/ballerina/scan/internal/ScanTool.java
+++ b/scan-command/src/main/java/io/ballerina/scan/internal/ScanTool.java
@@ -22,10 +22,6 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import io.ballerina.projects.BuildOptions;
-import io.ballerina.projects.Document;
-import io.ballerina.projects.DocumentId;
-import io.ballerina.projects.Module;
-import io.ballerina.projects.ModuleId;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.scan.ExcludedIssue;
@@ -44,7 +40,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -91,11 +86,6 @@ public class ScanTool {
                     .build();
 
             Project project = BuildProject.load(projectPath, buildOptions);
-
-            // Apply Unsaved Changes [[ Blocked By LS ]]           
-            if (isApplyUnsavedChanges && unsavedFileContent != null && !unsavedFileContent.isEmpty()) {
-                project = applyUnsavedChanges(project, unsavedFileContent, isSkipTests);
-            }
 
             // Run the scanner
             ScanResult result = runScan(project);
@@ -145,10 +135,6 @@ public class ScanTool {
                     .build();
 
             Project project = BuildProject.load(projectPath, buildOptions);
-
-            if (isApplyUnsavedChanges && unsavedFileContent != null && !unsavedFileContent.isEmpty()) {
-                project = applyUnsavedChanges(project, unsavedFileContent, isSkipTests);
-            }
 
             // Resolve the enclosing symbol and line hash
             String symbol = SymbolResolver.resolveSymbol(project, filePath, lineNumber);
@@ -438,43 +424,4 @@ public class ScanTool {
         }
         return obj;
     }
-
-    private static Project applyUnsavedChanges(Project project,
-                                                Map<String, String> unsavedContent, 
-                                                boolean isSkipTests) {
-        Map<DocumentId, String> updatesToApply = new HashMap<>();
-        for (Module module : project.currentPackage().modules()) {
-            for (DocumentId docId : module.documentIds()) {
-                Optional<Path> path = project.documentPath(docId);
-                if (path.isPresent()) {
-                    String absPath = path.get().toAbsolutePath().normalize().toString();
-                    if (unsavedContent.containsKey(absPath)) {
-                        updatesToApply.put(docId, unsavedContent.get(absPath));
-                    }
-                }
-            }
-            if (!isSkipTests) {
-                for (DocumentId docId : module.testDocumentIds()) {
-                    Optional<Path> path = project.documentPath(docId);
-                    if (path.isPresent()) {
-                        String absPath = path.get().toAbsolutePath().normalize().toString();
-                        if (unsavedContent.containsKey(absPath)) {
-                            updatesToApply.put(docId, unsavedContent.get(absPath));
-                        }
-                    }
-                }
-            }
-        }
-        Project currentProject = project;
-        for (Map.Entry<DocumentId, String> entry : updatesToApply.entrySet()) {
-            DocumentId docId = entry.getKey();
-            String newContent = entry.getValue();
-            ModuleId modId = docId.moduleId();
-            Module currentModule = currentProject.currentPackage().module(modId);
-            Document currentDoc = currentModule.document(docId);
-            currentProject = currentDoc.modify().withContent(newContent).apply().module().project();
-        }
-        return currentProject;
-    }
-
 }

--- a/scan-command/src/main/java/io/ballerina/scan/internal/ScanTool.java
+++ b/scan-command/src/main/java/io/ballerina/scan/internal/ScanTool.java
@@ -52,7 +52,7 @@ import java.util.Set;
 
 /**
  * {@code ScanTool} LANGUAGE SERVER ENTRY POINT
- * The core tool that executes and manage the security analysis.
+ * The core tool that executes and manages the security analysis.
  *
  * @since 0.11.1
  */
@@ -208,8 +208,11 @@ public class ScanTool {
                                          String ruleId, String symbol, String lineHash) {
         JsonObject result = new JsonObject();
         try {
-            String relativeFilePath = ScanUtils.getRelativePath(filePath, projectPathStr);
-            Path scanTomlPath = Paths.get(projectPathStr).resolve("Scan.toml");
+            Path projectPath = Paths.get(projectPathStr);
+            Project project = BuildProject.load(projectPath, BuildOptions.builder().build());
+            
+            String relativeFilePath = ScanUtils.getRelativePath(filePath, project.sourceRoot().toString());
+            Path scanTomlPath = projectPath.resolve("Scan.toml");
             ScanTomlWriter.removeExclusion(scanTomlPath, relativeFilePath, ruleId, symbol, lineHash);
 
             result.addProperty("success", true);
@@ -253,9 +256,7 @@ public class ScanTool {
     // CORE SCANNING LOGIC
     // ===================================================================================
 
-    private static ScanResult runScan(Project projectObj) {
-        Project project = (Project) projectObj;
-
+    private static ScanResult runScan(Project project) {
         PrintStream silentStream = new PrintStream(
                 new java.io.ByteArrayOutputStream(),
                 true,
@@ -263,10 +264,16 @@ public class ScanTool {
 
         // Load Scan.toml configurations
         Optional<ScanTomlFile> scanToml = ScanUtils.loadScanTomlConfigurations(project, silentStream);
-        ProjectAnalyzer analyzer = new ProjectAnalyzer(project, scanToml.orElse(null));
+        
+        // If Scan.toml is malformed or missing, return a failing ScanResult
+        if (scanToml.isEmpty()) {
+            return new ScanResult(new ArrayList<>(), new ArrayList<>());
+        }
+        
+        ProjectAnalyzer analyzer = new ProjectAnalyzer(project, scanToml.get());
 
         // Execute
-        return execute(analyzer, scanToml.orElse(null), project);
+        return execute(analyzer, scanToml.get(), project);
     }
 
     /**
@@ -311,31 +318,32 @@ public class ScanTool {
         List<ExcludedIssue> excludedIssues = new ArrayList<>();
 
         for (Issue issue : issues) {
-            boolean isExcluded = false;
-            boolean isGlobalExclusion = false;
+            boolean isExcluded;
+            boolean isGlobalExclusion;
             String issueFileName = issue.location() != null && issue.location().lineRange() != null
                     ? issue.location().lineRange().fileName() : "";
             String ruleId = issue.rule() != null ? issue.rule().id() : "";
 
             String issueSymbol = "";
             String issueLineHash = "";
+            boolean isExcludedByLocal = false;
+            boolean isExcludedByGlobal = false;
 
             if (!includeRules.isEmpty() && !includeRules.contains(ruleId)) {
-                isExcluded = true;
-                isGlobalExclusion = true;
+                isExcludedByGlobal = true;
             }
 
             if (!excludeRules.isEmpty() && excludeRules.contains(ruleId)) {
-                isExcluded = true;
-                isGlobalExclusion = true;
+                isExcludedByGlobal = true;
             }
 
-            // Resolve context data if available and not globally excluded
-            if (!isExcluded && scanToml != null && project != null) {
+            // Resolve context data for local exclusions whenever possible.
+            if (scanToml != null && project != null) {
                 Set<ScanTomlFile.Exclusion> exclusions = scanToml.getExclusions();
                 if (!exclusions.isEmpty()) {
                     if (issue.location() != null && issue.location().lineRange() != null
-                            && issue.location().lineRange().fileName() != null) {
+                            && issue.location().lineRange().fileName() != null
+                            && issue.location().lineRange().startLine() != null) {
                         int issueLine = issue.location().lineRange().startLine().line();
                         issueSymbol = SymbolResolver.resolveSymbol(project, issueFileName, issueLine);
                         issueLineHash = SymbolResolver.resolveLineHash(project, issueFileName, issueLine);
@@ -343,16 +351,20 @@ public class ScanTool {
                         String finalExSymbol = issueSymbol;
                         String finalExLineHash = issueLineHash;
 
-                        isExcluded = exclusions.stream().anyMatch(exclusion ->
+                        isExcludedByLocal = exclusions.stream().anyMatch(exclusion ->
                                 ScanUtils.matchesExclusion(issueFileName, ruleId,
                                         finalExSymbol, finalExLineHash, exclusion));
                     }
                 }
             }
 
+            isExcluded = isExcludedByLocal || isExcludedByGlobal;
+            isGlobalExclusion = isExcludedByGlobal && !isExcludedByLocal;
+
             if (isExcluded) {
                 if (issueSymbol.isEmpty() && project != null && issue.location() != null
-                        && issue.location().lineRange() != null) {
+                        && issue.location().lineRange() != null
+                        && issue.location().lineRange().startLine() != null) {
                     int issueLine = issue.location().lineRange().startLine().line();
                     issueSymbol = SymbolResolver.resolveSymbol(project, issueFileName, issueLine);
                     issueLineHash = SymbolResolver.resolveLineHash(project, issueFileName, issueLine);
@@ -388,7 +400,7 @@ public class ScanTool {
             obj.addProperty("ruleId", ex.ruleId());
             obj.addProperty("symbol", ex.symbol());
             obj.addProperty("isGlobalExclusion", ex.isGlobalExclusion());
-            obj.add("IssueContext", issueToJsonObject(ex.issue()));
+            obj.add("issueContext", issueToJsonObject(ex.issue()));
             jsonArray.add(obj);
         }
         return jsonArray;

--- a/scan-command/src/main/java/io/ballerina/scan/internal/ScanTool.java
+++ b/scan-command/src/main/java/io/ballerina/scan/internal/ScanTool.java
@@ -94,7 +94,7 @@ public class ScanTool {
 
             // Apply Unsaved Changes [[ Blocked By LS ]]           
             if (isApplyUnsavedChanges && unsavedFileContent != null && !unsavedFileContent.isEmpty()) {
-                project = applyUnsavedChanges(project, unsavedFileContent);
+                project = applyUnsavedChanges(project, unsavedFileContent, isSkipTests);
             }
 
             // Run the scanner
@@ -122,7 +122,8 @@ public class ScanTool {
      * entry to the Scan.toml file.
      */
     public static String addExclusion(String projectPathStr, String filePath, int lineNumber,
-                                      String ruleId, Map<String, Boolean> buildOptionsMap) {
+                                      String ruleId, Map<String, String> unsavedFileContent,
+                                      Map<String, Boolean> buildOptionsMap) {
         JsonObject result = new JsonObject();
         try {
             Path projectPath = Paths.get(projectPathStr);
@@ -134,6 +135,8 @@ public class ScanTool {
                     .TRUE.equals(buildOptionsMap.get("sticky"));
             boolean isSkipTests = buildOptionsMap != null && Boolean
                     .TRUE.equals(buildOptionsMap.get("skipTests"));
+            boolean isApplyUnsavedChanges = buildOptionsMap != null && Boolean
+                    .TRUE.equals(buildOptionsMap.get("applyUnsavedChanges"));
 
             BuildOptions buildOptions = BuildOptions.builder()
                     .setOffline(isOffline)
@@ -143,16 +146,21 @@ public class ScanTool {
 
             Project project = BuildProject.load(projectPath, buildOptions);
 
+            if (isApplyUnsavedChanges && unsavedFileContent != null && !unsavedFileContent.isEmpty()) {
+                project = applyUnsavedChanges(project, unsavedFileContent, isSkipTests);
+            }
+
             // Resolve the enclosing symbol and line hash
             String symbol = SymbolResolver.resolveSymbol(project, filePath, lineNumber);
             String lineHash = SymbolResolver.resolveLineHash(project, filePath, lineNumber);
 
             // Write the exclusion to Scan.toml
             Path scanTomlPath = projectPath.resolve("Scan.toml");
-            ScanTomlWriter.addExclusion(scanTomlPath, filePath, ruleId, symbol, lineHash);
+            String relativeFilePath = ScanUtils.getRelativePath(filePath, project.sourceRoot().toString());
+            ScanTomlWriter.addExclusion(scanTomlPath, relativeFilePath, ruleId, symbol, lineHash);
 
             result.addProperty("success", true);
-            result.addProperty("filePath", filePath);
+            result.addProperty("filePath", relativeFilePath);
             result.addProperty("ruleId", ruleId);
             result.addProperty("symbol", symbol);
             result.addProperty("lineHash", lineHash);
@@ -200,11 +208,12 @@ public class ScanTool {
                                          String ruleId, String symbol, String lineHash) {
         JsonObject result = new JsonObject();
         try {
+            String relativeFilePath = ScanUtils.getRelativePath(filePath, projectPathStr);
             Path scanTomlPath = Paths.get(projectPathStr).resolve("Scan.toml");
-            ScanTomlWriter.removeExclusion(scanTomlPath, filePath, ruleId, symbol, lineHash);
+            ScanTomlWriter.removeExclusion(scanTomlPath, relativeFilePath, ruleId, symbol, lineHash);
 
             result.addProperty("success", true);
-            result.addProperty("filePath", filePath);
+            result.addProperty("filePath", relativeFilePath);
             result.addProperty("ruleId", ruleId);
             result.addProperty("message", "Exclusion removed successfully.");
         } catch (IOException e) {
@@ -418,7 +427,9 @@ public class ScanTool {
         return obj;
     }
 
-    private static Project applyUnsavedChanges(Project project, Map<String, String> unsavedContent) {
+    private static Project applyUnsavedChanges(Project project,
+                                                Map<String, String> unsavedContent, 
+                                                boolean isSkipTests) {
         Map<DocumentId, String> updatesToApply = new HashMap<>();
         for (Module module : project.currentPackage().modules()) {
             for (DocumentId docId : module.documentIds()) {
@@ -427,6 +438,17 @@ public class ScanTool {
                     String absPath = path.get().toAbsolutePath().normalize().toString();
                     if (unsavedContent.containsKey(absPath)) {
                         updatesToApply.put(docId, unsavedContent.get(absPath));
+                    }
+                }
+            }
+            if (!isSkipTests) {
+                for (DocumentId docId : module.testDocumentIds()) {
+                    Optional<Path> path = project.documentPath(docId);
+                    if (path.isPresent()) {
+                        String absPath = path.get().toAbsolutePath().normalize().toString();
+                        if (unsavedContent.containsKey(absPath)) {
+                            updatesToApply.put(docId, unsavedContent.get(absPath));
+                        }
                     }
                 }
             }

--- a/scan-command/src/main/java/io/ballerina/scan/internal/ScanTool.java
+++ b/scan-command/src/main/java/io/ballerina/scan/internal/ScanTool.java
@@ -1,0 +1,438 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.scan.internal;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import io.ballerina.projects.BuildOptions;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.DocumentId;
+import io.ballerina.projects.Module;
+import io.ballerina.projects.ModuleId;
+import io.ballerina.projects.Project;
+import io.ballerina.projects.directory.BuildProject;
+import io.ballerina.scan.ExcludedIssue;
+import io.ballerina.scan.Issue;
+import io.ballerina.scan.Rule;
+import io.ballerina.scan.ScanResult;
+import io.ballerina.scan.utils.ScanTomlFile;
+import io.ballerina.scan.utils.ScanTomlWriter;
+import io.ballerina.scan.utils.ScanUtils;
+import io.ballerina.scan.utils.SymbolResolver;
+import io.ballerina.tools.text.LineRange;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * {@code ScanTool} LANGUAGE SERVER ENTRY POINT
+ * The core tool that executes and manage the security analysis.
+ *
+ * @since 0.11.1
+ */
+public class ScanTool {
+    private static final Gson GSON = new Gson();
+
+    // ===================================================================================
+    // PUBLIC LS ENTRY POINTS
+    // ===================================================================================
+
+    /**
+     * ENTRY POINT TO RUN A SCAN
+     * Returns a JSON string of issues.
+     */
+    public static String runScan(String projectPathStr,
+                                 Map<String, String> unsavedFileContent,
+                                 Map<String, Boolean> buildOptionsMap) {
+        try {
+            Path projectPath = Paths.get(projectPathStr);
+
+            // Extract Build Options
+            boolean isOffline = buildOptionsMap != null && Boolean
+                    .TRUE.equals(buildOptionsMap.get("offline"));
+            boolean isSticky = buildOptionsMap != null && Boolean
+                    .TRUE.equals(buildOptionsMap.get("sticky"));
+            boolean isSkipTests = buildOptionsMap != null && Boolean
+                    .TRUE.equals(buildOptionsMap.get("skipTests"));
+            boolean isApplyUnsavedChanges = buildOptionsMap != null && Boolean
+                    .TRUE.equals(buildOptionsMap.get("applyUnsavedChanges"));
+
+            // Load Project from Disk with Options
+            BuildOptions buildOptions = BuildOptions.builder()
+                    .setOffline(isOffline)
+                    .setSticky(isSticky)
+                    .setSkipTests(isSkipTests)
+                    .build();
+
+            Project project = BuildProject.load(projectPath, buildOptions);
+
+            // Apply Unsaved Changes [[ Blocked By LS ]]           
+            if (isApplyUnsavedChanges && unsavedFileContent != null && !unsavedFileContent.isEmpty()) {
+                project = applyUnsavedChanges(project, unsavedFileContent);
+            }
+
+            // Run the scanner
+            ScanResult result = runScan(project);
+
+            // Convert to JSON
+            JsonObject jsonObject = new JsonObject();
+            jsonObject.add("activeIssues", issuesToJsonArray(result.activeIssues()));
+            jsonObject.add("excludedIssues", excludedIssuesToJsonArray(result.excludedIssues()));
+            return GSON.toJson(jsonObject);
+
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            return "{\"activeIssues\": [], \"excludedIssues\": []}";
+        }
+    }
+
+    /**
+     * ENTRY POINT FOR ADDING EXCLUSIONS
+     * Resolves the AST symbol at the given line and writes a symbol-based exclusion
+     * entry to the Scan.toml file.
+     */
+    public static String addExclusion(String projectPathStr, String filePath, int lineNumber,
+                                      String ruleId, Map<String, Boolean> buildOptionsMap) {
+        JsonObject result = new JsonObject();
+        try {
+            Path projectPath = Paths.get(projectPathStr);
+
+            // Extract Build Options
+            boolean isOffline = buildOptionsMap != null && Boolean
+                    .TRUE.equals(buildOptionsMap.get("offline"));
+            boolean isSticky = buildOptionsMap != null && Boolean
+                    .TRUE.equals(buildOptionsMap.get("sticky"));
+            boolean isSkipTests = buildOptionsMap != null && Boolean
+                    .TRUE.equals(buildOptionsMap.get("skipTests"));
+
+            BuildOptions buildOptions = BuildOptions.builder()
+                    .setOffline(isOffline)
+                    .setSticky(isSticky)
+                    .setSkipTests(isSkipTests)
+                    .build();
+
+            Project project = BuildProject.load(projectPath, buildOptions);
+
+            // Resolve the enclosing symbol and line hash
+            String symbol = SymbolResolver.resolveSymbol(project, filePath, lineNumber);
+            String lineHash = SymbolResolver.resolveLineHash(project, filePath, lineNumber);
+
+            // Write the exclusion to Scan.toml
+            Path scanTomlPath = projectPath.resolve("Scan.toml");
+            ScanTomlWriter.addExclusion(scanTomlPath, filePath, ruleId, symbol, lineHash);
+
+            result.addProperty("success", true);
+            result.addProperty("filePath", filePath);
+            result.addProperty("ruleId", ruleId);
+            result.addProperty("symbol", symbol);
+            result.addProperty("lineHash", lineHash);
+            result.addProperty("message", "Exclusion added successfully for symbol '" + symbol
+                    + "' in file '" + filePath + "' for rule '" + ruleId + "'");
+        } catch (IOException e) {
+            result.addProperty("success", false);
+            result.addProperty("error", "Failed to write exclusion to Scan.toml: " + e.getMessage());
+        } catch (RuntimeException e) {
+            result.addProperty("success", false);
+            result.addProperty("error", "Failed to add exclusion: " + e.getMessage());
+        }
+        return GSON.toJson(result);
+    }
+
+    /**
+     * ENTRY POINT FOR ADDING GLOBAL EXCLUSIONS
+     * Adds a rule ID to the global `[rule]` section in Scan.toml.
+     */
+    public static String addGlobalExclusion(String projectPathStr, String ruleId) {
+        JsonObject result = new JsonObject();
+        try {
+            Path projectPath = Paths.get(projectPathStr);
+            Path scanTomlPath = projectPath.resolve("Scan.toml");
+            ScanTomlWriter.addGlobalExclusion(scanTomlPath, ruleId);
+
+            result.addProperty("success", true);
+            result.addProperty("ruleId", ruleId);
+            result.addProperty("message", "Global exclusion added successfully for rule '" + ruleId + "'");
+        } catch (IOException e) {
+            result.addProperty("success", false);
+            result.addProperty("error", "Failed to write global exclusion to Scan.toml: " + e.getMessage());
+        } catch (RuntimeException e) {
+            result.addProperty("success", false);
+            result.addProperty("error", "Failed to add global exclusion: " + e.getMessage());
+        }
+        return GSON.toJson(result);
+    }
+
+    /**
+     * ENTRY POINT FOR REMOVING EXCLUSIONS
+     * Removes a symbol-based exclusion entry from the Scan.toml file.
+     */
+    public static String removeExclusion(String projectPathStr, String filePath,
+                                         String ruleId, String symbol, String lineHash) {
+        JsonObject result = new JsonObject();
+        try {
+            Path scanTomlPath = Paths.get(projectPathStr).resolve("Scan.toml");
+            ScanTomlWriter.removeExclusion(scanTomlPath, filePath, ruleId, symbol, lineHash);
+
+            result.addProperty("success", true);
+            result.addProperty("filePath", filePath);
+            result.addProperty("ruleId", ruleId);
+            result.addProperty("message", "Exclusion removed successfully.");
+        } catch (IOException e) {
+            result.addProperty("success", false);
+            result.addProperty("error", "Failed to remove exclusion: " + e.getMessage());
+        } catch (RuntimeException e) {
+            result.addProperty("success", false);
+            result.addProperty("error", "Failed to remove exclusion due to unexpected error: " + e.getMessage());
+        }
+        return GSON.toJson(result);
+    }
+
+    /**
+     * ENTRY POINT FOR REMOVING GLOBAL EXCLUSIONS
+     * Removes a rule ID from the global `[rule]` section in Scan.toml.
+     */
+    public static String removeGlobalExclusion(String projectPathStr, String ruleId) {
+        JsonObject result = new JsonObject();
+        try {
+            Path scanTomlPath = Paths.get(projectPathStr).resolve("Scan.toml");
+            ScanTomlWriter.removeGlobalExclusion(scanTomlPath, ruleId);
+
+            result.addProperty("success", true);
+            result.addProperty("ruleId", ruleId);
+            result.addProperty("message", "Global exclusion removed successfully.");
+        } catch (IOException e) {
+            result.addProperty("success", false);
+            result.addProperty("error", "Failed to remove global exclusion: " + e.getMessage());
+        } catch (RuntimeException e) {
+            result.addProperty("success", false);
+            result.addProperty("error", "Failed to remove global exclusion due to unexpected error: " + e.getMessage());
+        }
+        return GSON.toJson(result);
+    }
+
+    // ===================================================================================
+    // CORE SCANNING LOGIC
+    // ===================================================================================
+
+    public static ScanResult runScan(Object projectObj) {
+        if (projectObj instanceof Project) {
+            Project project = (Project) projectObj;
+
+            PrintStream silentStream = new PrintStream(
+                    new java.io.ByteArrayOutputStream(),
+                    true,
+                    StandardCharsets.UTF_8);
+
+            // Load Scan.toml configurations
+            Optional<ScanTomlFile> scanToml = ScanUtils.loadScanTomlConfigurations(project, silentStream);
+            ProjectAnalyzer analyzer = new ProjectAnalyzer(project, scanToml.orElse(null));
+
+            // Execute
+            return execute(analyzer, scanToml.orElse(null), project);
+        }
+        return new ScanResult(Collections.emptyList(), Collections.emptyList());
+    }
+
+    public static ScanResult execute(ProjectAnalyzer projectAnalyzer,
+                                     ScanTomlFile scanToml, Project project) {
+        // Gather all available Rules
+        List<Rule> coreRules = CoreRule.rules();
+        Map<String, List<Rule>> externalAnalyzers = new HashMap<>();
+
+        try {
+            externalAnalyzers = projectAnalyzer.getExternalAnalyzers();
+        } catch (RuntimeException e) {
+            // Log error if needed
+        }
+
+        // Prepare Filter Lists
+        List<String> includeRules = new ArrayList<>();
+        List<String> excludeRules = new ArrayList<>();
+
+        if (scanToml != null) {
+            scanToml.getRulesToInclude().stream()
+                    .map(ScanTomlFile.RuleToFilter::id)
+                    .forEach(includeRules::add);
+
+            scanToml.getRulesToExclude().stream()
+                    .map(ScanTomlFile.RuleToFilter::id)
+                    .forEach(excludeRules::add);
+        }
+
+        if (!includeRules.isEmpty() && !excludeRules.isEmpty()) {
+            return new ScanResult(Collections.emptyList(), Collections.emptyList());
+        }
+
+        // Run Analysis
+        List<Issue> issues = projectAnalyzer.analyze(coreRules);
+
+        if (!externalAnalyzers.isEmpty()) {
+            issues.addAll(projectAnalyzer.runExternalAnalyzers(externalAnalyzers));
+        }
+
+        List<Issue> activeIssues = new ArrayList<>();
+        List<ExcludedIssue> excludedIssues = new ArrayList<>();
+
+        for (Issue issue : issues) {
+            boolean isExcluded = false;
+            boolean isGlobalExclusion = false;
+            String issueFileName = issue.location() != null && issue.location().lineRange() != null
+                    ? issue.location().lineRange().fileName() : "";
+            String ruleId = issue.rule() != null ? issue.rule().id() : "";
+
+            String issueSymbol = "";
+            String issueLineHash = "";
+
+            if (!includeRules.isEmpty() && !includeRules.contains(ruleId)) {
+                isExcluded = true;
+                isGlobalExclusion = true;
+            }
+
+            if (!excludeRules.isEmpty() && excludeRules.contains(ruleId)) {
+                isExcluded = true;
+                isGlobalExclusion = true;
+            }
+
+            // Resolve context data if available and not globally excluded
+            if (!isExcluded && scanToml != null && project != null) {
+                Set<ScanTomlFile.Exclusion> exclusions = scanToml.getExclusions();
+                if (!exclusions.isEmpty()) {
+                    if (issue.location() != null && issue.location().lineRange() != null
+                            && issue.location().lineRange().fileName() != null) {
+                        int issueLine = issue.location().lineRange().startLine().line();
+                        issueSymbol = SymbolResolver.resolveSymbol(project, issueFileName, issueLine);
+                        issueLineHash = SymbolResolver.resolveLineHash(project, issueFileName, issueLine);
+
+                        String finalExSymbol = issueSymbol;
+                        String finalExLineHash = issueLineHash;
+
+                        isExcluded = exclusions.stream().anyMatch(exclusion ->
+                                ScanUtils.matchesExclusion(issueFileName, ruleId,
+                                        finalExSymbol, finalExLineHash, exclusion));
+                    }
+                }
+            }
+
+            if (isExcluded) {
+                if (issueSymbol.isEmpty() && project != null && issue.location() != null
+                        && issue.location().lineRange() != null) {
+                    int issueLine = issue.location().lineRange().startLine().line();
+                    issueSymbol = SymbolResolver.resolveSymbol(project, issueFileName, issueLine);
+                    issueLineHash = SymbolResolver.resolveLineHash(project, issueFileName, issueLine);
+                }
+                excludedIssues.add(new ExcludedIssue(issue, ruleId, issueFileName, 
+                        issueSymbol, issueLineHash, isGlobalExclusion));
+            } else {
+                activeIssues.add(issue);
+            }
+        }
+
+        return new ScanResult(activeIssues, excludedIssues);
+    }
+
+    // ===================================================================================
+    // HELPER METHODS & SERIALIZATION
+    // ===================================================================================
+
+    private static JsonArray issuesToJsonArray(List<Issue> issues) {
+        JsonArray jsonArray = new JsonArray();
+        for (Issue issue : issues) {
+            jsonArray.add(issueToJsonObject(issue));
+        }
+        return jsonArray;
+    }
+
+    private static JsonArray excludedIssuesToJsonArray(List<ExcludedIssue> excludedIssues) {
+        JsonArray jsonArray = new JsonArray();
+        for (ExcludedIssue ex : excludedIssues) {
+            JsonObject obj = new JsonObject();
+            obj.addProperty("filePath", ex.filePath());
+            obj.addProperty("lineHash", ex.lineHash());
+            obj.addProperty("ruleId", ex.ruleId());
+            obj.addProperty("symbol", ex.symbol());
+            obj.addProperty("isGlobalExclusion", ex.isGlobalExclusion());
+            obj.add("IssueContext", issueToJsonObject(ex.issue()));
+            jsonArray.add(obj);
+        }
+        return jsonArray;
+    }
+
+    private static JsonObject issueToJsonObject(Issue issue) {
+        JsonObject obj = new JsonObject();
+        if (issue.rule() != null) {
+            obj.addProperty("ruleId", issue.rule().id());
+            obj.addProperty("message", issue.rule().description());
+            obj.addProperty("severity", issue.rule().kind() != null ? issue.rule().kind().toString() : "WARNING");
+            obj.addProperty("ruleKind", issue.rule().kind() != null ? issue.rule().kind().name() : "UNKNOWN");
+        } else {
+            obj.addProperty("ruleId", "UNKNOWN");
+            obj.addProperty("message", "Unknown Issue Rule");
+            obj.addProperty("severity", "WARNING");
+            obj.addProperty("ruleKind", "UNKNOWN");
+        }
+
+        if (issue.location() != null) {
+            LineRange range = issue.location().lineRange();
+            obj.addProperty("filePath", range.fileName());
+            obj.addProperty("startLine", range.startLine().line());
+            obj.addProperty("startColumn", range.startLine().offset());
+            obj.addProperty("endLine", range.endLine().line());
+            obj.addProperty("endColumn", range.endLine().offset());
+        }
+        return obj;
+    }
+
+    private static Project applyUnsavedChanges(Project project, Map<String, String> unsavedContent) {
+        Map<DocumentId, String> updatesToApply = new HashMap<>();
+        for (Module module : project.currentPackage().modules()) {
+            for (DocumentId docId : module.documentIds()) {
+                Optional<Path> path = project.documentPath(docId);
+                if (path.isPresent()) {
+                    String absPath = path.get().toAbsolutePath().normalize().toString();
+                    if (unsavedContent.containsKey(absPath)) {
+                        updatesToApply.put(docId, unsavedContent.get(absPath));
+                    }
+                }
+            }
+        }
+        Project currentProject = project;
+        for (Map.Entry<DocumentId, String> entry : updatesToApply.entrySet()) {
+            DocumentId docId = entry.getKey();
+            String newContent = entry.getValue();
+            ModuleId modId = docId.moduleId();
+            Module currentModule = currentProject.currentPackage().module(modId);
+            Document currentDoc = currentModule.document(docId);
+            currentProject = currentDoc.modify().withContent(newContent).apply().module().project();
+        }
+        return currentProject;
+    }
+
+}

--- a/scan-command/src/main/java/io/ballerina/scan/internal/ScanTool.java
+++ b/scan-command/src/main/java/io/ballerina/scan/internal/ScanTool.java
@@ -44,7 +44,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -107,10 +106,13 @@ public class ScanTool {
             jsonObject.add("excludedIssues", excludedIssuesToJsonArray(result.excludedIssues()));
             return GSON.toJson(jsonObject);
 
-        } catch (RuntimeException e) {
-            throw e;
         } catch (Exception e) {
-            return "{\"activeIssues\": [], \"excludedIssues\": []}";
+            JsonObject errorObject = new JsonObject();
+            errorObject.addProperty("success", false);
+            errorObject.addProperty("error", e.getMessage());
+            errorObject.add("activeIssues", new JsonArray());
+            errorObject.add("excludedIssues", new JsonArray());
+            return GSON.toJson(errorObject);
         }
     }
 
@@ -159,7 +161,7 @@ public class ScanTool {
         } catch (IOException e) {
             result.addProperty("success", false);
             result.addProperty("error", "Failed to write exclusion to Scan.toml: " + e.getMessage());
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             result.addProperty("success", false);
             result.addProperty("error", "Failed to add exclusion: " + e.getMessage());
         }
@@ -183,7 +185,7 @@ public class ScanTool {
         } catch (IOException e) {
             result.addProperty("success", false);
             result.addProperty("error", "Failed to write global exclusion to Scan.toml: " + e.getMessage());
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             result.addProperty("success", false);
             result.addProperty("error", "Failed to add global exclusion: " + e.getMessage());
         }
@@ -208,7 +210,7 @@ public class ScanTool {
         } catch (IOException e) {
             result.addProperty("success", false);
             result.addProperty("error", "Failed to remove exclusion: " + e.getMessage());
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             result.addProperty("success", false);
             result.addProperty("error", "Failed to remove exclusion due to unexpected error: " + e.getMessage());
         }
@@ -231,7 +233,7 @@ public class ScanTool {
         } catch (IOException e) {
             result.addProperty("success", false);
             result.addProperty("error", "Failed to remove global exclusion: " + e.getMessage());
-        } catch (RuntimeException e) {
+        } catch (Exception e) {
             result.addProperty("success", false);
             result.addProperty("error", "Failed to remove global exclusion due to unexpected error: " + e.getMessage());
         }
@@ -242,36 +244,33 @@ public class ScanTool {
     // CORE SCANNING LOGIC
     // ===================================================================================
 
-    public static ScanResult runScan(Object projectObj) {
-        if (projectObj instanceof Project) {
-            Project project = (Project) projectObj;
+    private static ScanResult runScan(Project projectObj) {
+        Project project = (Project) projectObj;
 
-            PrintStream silentStream = new PrintStream(
-                    new java.io.ByteArrayOutputStream(),
-                    true,
-                    StandardCharsets.UTF_8);
+        PrintStream silentStream = new PrintStream(
+                new java.io.ByteArrayOutputStream(),
+                true,
+                StandardCharsets.UTF_8);
 
-            // Load Scan.toml configurations
-            Optional<ScanTomlFile> scanToml = ScanUtils.loadScanTomlConfigurations(project, silentStream);
-            ProjectAnalyzer analyzer = new ProjectAnalyzer(project, scanToml.orElse(null));
+        // Load Scan.toml configurations
+        Optional<ScanTomlFile> scanToml = ScanUtils.loadScanTomlConfigurations(project, silentStream);
+        ProjectAnalyzer analyzer = new ProjectAnalyzer(project, scanToml.orElse(null));
 
-            // Execute
-            return execute(analyzer, scanToml.orElse(null), project);
-        }
-        return new ScanResult(Collections.emptyList(), Collections.emptyList());
+        // Execute
+        return execute(analyzer, scanToml.orElse(null), project);
     }
 
-    public static ScanResult execute(ProjectAnalyzer projectAnalyzer,
-                                     ScanTomlFile scanToml, Project project) {
+    /**
+     * Executes scanning with include/exclude filters resolved from Scan.toml.
+     *
+     * @throws IllegalArgumentException when both include and exclude rule filters are configured,
+     *                                  since they are mutually exclusive.
+     */
+    private static ScanResult execute(ProjectAnalyzer projectAnalyzer,
+                                      ScanTomlFile scanToml, Project project) {
         // Gather all available Rules
         List<Rule> coreRules = CoreRule.rules();
-        Map<String, List<Rule>> externalAnalyzers = new HashMap<>();
-
-        try {
-            externalAnalyzers = projectAnalyzer.getExternalAnalyzers();
-        } catch (RuntimeException e) {
-            // Log error if needed
-        }
+        Map<String, List<Rule>> externalAnalyzers = projectAnalyzer.getExternalAnalyzers();
 
         // Prepare Filter Lists
         List<String> includeRules = new ArrayList<>();
@@ -288,7 +287,8 @@ public class ScanTool {
         }
 
         if (!includeRules.isEmpty() && !excludeRules.isEmpty()) {
-            return new ScanResult(Collections.emptyList(), Collections.emptyList());
+            throw new IllegalArgumentException("Invalid Scan.toml configuration: both include and exclude rule "
+                    + "filters are set. Configure only one of [rule.include] or [rule.exclude].");
         }
 
         // Run Analysis
@@ -401,11 +401,19 @@ public class ScanTool {
 
         if (issue.location() != null) {
             LineRange range = issue.location().lineRange();
-            obj.addProperty("filePath", range.fileName());
-            obj.addProperty("startLine", range.startLine().line());
-            obj.addProperty("startColumn", range.startLine().offset());
-            obj.addProperty("endLine", range.endLine().line());
-            obj.addProperty("endColumn", range.endLine().offset());
+            if (range != null) {
+                if (range.fileName() != null) {
+                    obj.addProperty("filePath", range.fileName());
+                }
+                if (range.startLine() != null) {
+                    obj.addProperty("startLine", range.startLine().line());
+                    obj.addProperty("startColumn", range.startLine().offset());
+                }
+                if (range.endLine() != null) {
+                    obj.addProperty("endLine", range.endLine().line());
+                    obj.addProperty("endColumn", range.endLine().offset());
+                }
+            }
         }
         return obj;
     }

--- a/scan-command/src/main/java/io/ballerina/scan/utils/Constants.java
+++ b/scan-command/src/main/java/io/ballerina/scan/utils/Constants.java
@@ -51,7 +51,7 @@ public class Constants {
     static final String SCAN_REPORT_ISSUE_TEXT_RANGE_END_LINE_OFFSET = "endLineOffset";
     static final String SCAN_TABLE = "scan";
     static final String SCAN_FILE_FIELD = "configPath";
-    static final String SCAN_FILE = "Scan.toml";
+    public static final String SCAN_FILE = "Scan.toml";
     static final String PLATFORM_TABLE = "platform";
     static final String PLATFORM_NAME = "name";
     static final String PLATFORM_PATH = "path";

--- a/scan-command/src/main/java/io/ballerina/scan/utils/Constants.java
+++ b/scan-command/src/main/java/io/ballerina/scan/utils/Constants.java
@@ -60,6 +60,13 @@ public class Constants {
     static final String ANALYZER_VERSION = "version";
     static final String ANALYZER_REPOSITORY = "repository";
     static final String RULES_TABLE = "rule";
+    static final String EXCLUSION_TABLE = "exclusion";
+    static final String EXCLUSION_FILE_PATH = "filePath";
+    static final String EXCLUSION_RULE_ID = "ruleId";
+    static final String EXCLUSION_SYMBOL = "symbol";
+    static final String EXCLUSION_LINE_HASH = "lineHash";
+    static final String EXCLUDE_KEY = "exclude";
+    public static final String MODULE_LEVEL_SYMBOL = "<module>";
     static final String JAR_PREDICATE = ".jar";
     static final String CUSTOM_RULES_COMPILER_PLUGIN_VERSION_PATTERN = "^\\d+\\.\\d+\\.\\d+$";
     static final String RULE_ID_COLUMN = "RuleID";

--- a/scan-command/src/main/java/io/ballerina/scan/utils/ScanTomlFile.java
+++ b/scan-command/src/main/java/io/ballerina/scan/utils/ScanTomlFile.java
@@ -33,6 +33,7 @@ public class ScanTomlFile {
     private final Set<Analyzer> analyzers = new LinkedHashSet<>();
     private final Set<RuleToFilter> rulesToInclude = new LinkedHashSet<>();
     private final Set<RuleToFilter> rulesToExclude = new LinkedHashSet<>();
+    private final Set<Exclusion> exclusions = new LinkedHashSet<>();
 
     ScanTomlFile() {
     }
@@ -51,6 +52,10 @@ public class ScanTomlFile {
 
     void setRuleToExclude(RuleToFilter rule) {
         rulesToExclude.add(rule);
+    }
+
+    void addExclusion(Exclusion exclusion) {
+        exclusions.add(exclusion);
     }
 
     /**
@@ -90,6 +95,15 @@ public class ScanTomlFile {
     }
 
     /**
+     * Returns an unmodifiable {@link Set} of symbol-based exclusions.
+     *
+     * @return an unmodifiable set of symbol-based exclusions
+     */
+    public Set<Exclusion> getExclusions() {
+        return Collections.unmodifiableSet(exclusions);
+    }
+
+    /**
      * Represents a static code analysis platform.
      *
      * @param name      in-memory representation of platform name
@@ -118,4 +132,15 @@ public class ScanTomlFile {
      * @param id in-memory representation of the identifier of the rule to filter
      */
     public record RuleToFilter(String id) { }
+
+    /**
+     * Represents a symbol-based exclusion for suppressing a specific rule violation
+     * within a named code construct (function, class, service, etc.).
+     *
+     * @param filePath in-memory representation of the file path relative to the project root
+     * @param ruleId   in-memory representation of the fully qualified rule identifier
+     * @param symbol   in-memory representation of the enclosing symbol name
+     * @param lineHash in-memory representation of the hashed line content
+     */
+    public record Exclusion(String filePath, String ruleId, String symbol, String lineHash) { }
 }

--- a/scan-command/src/main/java/io/ballerina/scan/utils/ScanTomlWriter.java
+++ b/scan-command/src/main/java/io/ballerina/scan/utils/ScanTomlWriter.java
@@ -360,14 +360,34 @@ public final class ScanTomlWriter {
             }
             sb.append("]");
         } else if (value instanceof Map) {
-            // fallback to empty
-            sb.append("{ }");
+            writeInlineTable(sb, (Map<?, ?>) value);
         } else {
             sb.append(value);
         }
     }
 
+    private static void writeInlineTable(StringBuilder sb, Map<?, ?> map) {
+        sb.append("{ ");
+        int index = 0;
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            sb.append(String.valueOf(entry.getKey())).append(" = ");
+            writeValue(sb, entry.getValue());
+            if (index < map.size() - 1) {
+                sb.append(", ");
+            }
+            index++;
+        }
+        sb.append(" }");
+    }
+
     private static String escapeTomlString(String value) {
-        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+        return value
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t")
+                .replace("\b", "\\b")
+                .replace("\f", "\\f");
     }
 }

--- a/scan-command/src/main/java/io/ballerina/scan/utils/ScanTomlWriter.java
+++ b/scan-command/src/main/java/io/ballerina/scan/utils/ScanTomlWriter.java
@@ -1,0 +1,373 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.scan.utils;
+
+import io.ballerina.toml.api.Toml;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * {@code ScanTomlWriter} provides utilities for creating and modifying Scan.toml files,
+ * specifically for adding symbol-based and global exclusion entries.
+ *
+ * @since 0.11.1
+ */
+public final class ScanTomlWriter {
+
+    private ScanTomlWriter() {
+    }
+
+    /**
+     * Adds a symbol-based exclusion entry to the Scan.toml file at the given path.
+     * If the file does not exist, it will be created. Duplicate entries are not added.
+     *
+     * @param scanTomlPath the path to the Scan.toml file
+     * @param filePath     the relative file path for the exclusion
+     * @param ruleId       the fully qualified rule identifier
+     * @param symbol       the enclosing symbol name
+     * @param lineHash     the hashed line content
+     * @throws IOException if an I/O error occurs while reading or writing the file
+     */
+    public static void addExclusion(Path scanTomlPath, String filePath, String ruleId, String symbol, String lineHash)
+            throws IOException {
+        modifyAndWrite(scanTomlPath, tomlMap -> {
+            List<Map<String, Object>> exclusions = getOrCreateTableArray(tomlMap, Constants.EXCLUSION_TABLE);
+
+            // Check for duplicate entry
+            for (Map<String, Object> ex : exclusions) {
+                if (Objects.equals(ex.get(Constants.EXCLUSION_FILE_PATH), filePath) &&
+                        Objects.equals(ex.get(Constants.EXCLUSION_RULE_ID), ruleId) &&
+                        Objects.equals(ex.get(Constants.EXCLUSION_SYMBOL), symbol) &&
+                        Objects.equals(ex.get(Constants.EXCLUSION_LINE_HASH), lineHash)) {
+                    return;
+                }
+            }
+
+            Map<String, Object> newExclusion = new LinkedHashMap<>();
+            newExclusion.put(Constants.EXCLUSION_FILE_PATH, filePath);
+            newExclusion.put(Constants.EXCLUSION_RULE_ID, ruleId);
+            newExclusion.put(Constants.EXCLUSION_SYMBOL, symbol);
+            newExclusion.put(Constants.EXCLUSION_LINE_HASH, lineHash);
+            exclusions.add(newExclusion);
+        });
+    }
+
+    /**
+     * Adds multiple symbol-based exclusion entries to the Scan.toml file.
+     *
+     * @param scanTomlPath the path to the Scan.toml file
+     * @param exclusions   the set of exclusions to add
+     * @throws IOException if an I/O error occurs
+     */
+    public static void addExclusions(Path scanTomlPath, Set<ScanTomlFile.Exclusion> exclusions) throws IOException {
+        modifyAndWrite(scanTomlPath, tomlMap -> {
+            List<Map<String, Object>> exclusionList = getOrCreateTableArray(tomlMap, Constants.EXCLUSION_TABLE);
+
+            for (ScanTomlFile.Exclusion exclusion : exclusions) {
+                boolean duplicate = false;
+                for (Map<String, Object> ex : exclusionList) {
+                    if (Objects.equals(ex.get(Constants.EXCLUSION_FILE_PATH), exclusion.filePath()) &&
+                            Objects.equals(ex.get(Constants.EXCLUSION_RULE_ID), exclusion.ruleId()) &&
+                            Objects.equals(ex.get(Constants.EXCLUSION_SYMBOL), exclusion.symbol()) &&
+                            Objects.equals(ex.get(Constants.EXCLUSION_LINE_HASH), exclusion.lineHash())) {
+                        duplicate = true;
+                        break;
+                    }
+                }
+                if (!duplicate) {
+                    Map<String, Object> newExclusion = new LinkedHashMap<>();
+                    newExclusion.put(Constants.EXCLUSION_FILE_PATH, exclusion.filePath());
+                    newExclusion.put(Constants.EXCLUSION_RULE_ID, exclusion.ruleId());
+                    newExclusion.put(Constants.EXCLUSION_SYMBOL, exclusion.symbol());
+                    newExclusion.put(Constants.EXCLUSION_LINE_HASH, exclusion.lineHash());
+                    exclusionList.add(newExclusion);
+                }
+            }
+        });
+    }
+
+    /**
+     * Adds a rule ID to the global [rule] exclude array in Scan.toml.
+     *
+     * @param scanTomlPath the path to the Scan.toml file
+     * @param ruleId       the rule identifier to globally exclude
+     * @throws IOException if an I/O error occurs
+     */
+    public static void addGlobalExclusion(Path scanTomlPath, String ruleId) throws IOException {
+        modifyAndWrite(scanTomlPath, tomlMap -> {
+            Map<String, Object> ruleMap = getOrCreateTable(tomlMap, Constants.RULES_TABLE);
+            List<Object> excludeList = getOrCreateArray(ruleMap, Constants.EXCLUDE_KEY);
+
+            if (!excludeList.contains(ruleId)) {
+                excludeList.add(ruleId);
+            }
+        });
+    }
+
+    /**
+     * Removes a symbol-based exclusion entry from the Scan.toml file.
+     *
+     * @param scanTomlPath the path to the Scan.toml file
+     * @param filePath     the relative file path for the exclusion
+     * @param ruleId       the fully qualified rule identifier
+     * @param symbol       the enclosing symbol name
+     * @param lineHash     the hashed line content
+     * @throws IOException if an I/O error occurs
+     */
+    public static void removeExclusion(Path scanTomlPath, String filePath, String ruleId, String symbol, 
+            String lineHash)
+            throws IOException {
+        modifyAndWrite(scanTomlPath, tomlMap -> {
+            if (tomlMap.containsKey(Constants.EXCLUSION_TABLE) && 
+                    tomlMap.get(Constants.EXCLUSION_TABLE) instanceof List) {
+                @SuppressWarnings("unchecked")
+                List<Map<String, Object>> exclusions = 
+                        (List<Map<String, Object>>) tomlMap.get(Constants.EXCLUSION_TABLE);
+                exclusions.removeIf(ex ->
+                        Objects.equals(ex.get(Constants.EXCLUSION_FILE_PATH), filePath) &&
+                        Objects.equals(ex.get(Constants.EXCLUSION_RULE_ID), ruleId) &&
+                        Objects.equals(ex.get(Constants.EXCLUSION_SYMBOL), symbol) &&
+                        Objects.equals(ex.get(Constants.EXCLUSION_LINE_HASH), lineHash)
+                );
+                
+                if (exclusions.isEmpty()) {
+                    tomlMap.remove(Constants.EXCLUSION_TABLE);
+                }
+            }
+        });
+    }
+
+    /**
+     * Removes a rule ID from the global [rule] exclude array in Scan.toml.
+     *
+     * @param scanTomlPath the path to the Scan.toml file
+     * @param ruleId       the rule identifier to globally remove from exclusions
+     * @throws IOException if an I/O error occurs
+     */
+    public static void removeGlobalExclusion(Path scanTomlPath, String ruleId) throws IOException {
+        modifyAndWrite(scanTomlPath, tomlMap -> {
+            if (tomlMap.containsKey(Constants.RULES_TABLE) && tomlMap.get(Constants.RULES_TABLE) instanceof Map) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> ruleMap = (Map<String, Object>) tomlMap.get(Constants.RULES_TABLE);
+                if (ruleMap.containsKey(Constants.EXCLUDE_KEY) && ruleMap.get(Constants.EXCLUDE_KEY) instanceof List) {
+                    List<?> excludeList = (List<?>) ruleMap.get(Constants.EXCLUDE_KEY);
+                    excludeList.remove(ruleId);
+
+                    if (excludeList.isEmpty()) {
+                        ruleMap.remove(Constants.EXCLUDE_KEY);
+                        if (ruleMap.isEmpty()) {
+                            tomlMap.remove(Constants.RULES_TABLE);
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    // --- Core Modification Logic ---
+
+    private interface Modifier {
+        void modify(Map<String, Object> tomlMap);
+    }
+
+    private static void modifyAndWrite(Path scanTomlPath, Modifier modifier) throws IOException {
+        Map<String, Object> tomlMap = new HashMap<>();
+        if (Files.exists(scanTomlPath)) {
+            String content = Files.readString(scanTomlPath, StandardCharsets.UTF_8).trim();
+            if (!content.isEmpty()) {
+                Toml toml = Toml.read(scanTomlPath);
+                tomlMap = deepMutableCopy(toml.toMap());
+            }
+        }
+
+        modifier.modify(tomlMap);
+
+        Path parentDir = scanTomlPath.getParent();
+        if (parentDir != null) {
+            Files.createDirectories(parentDir);
+        }
+
+        String newTomlContent = generateTomlString(tomlMap);
+        Files.writeString(scanTomlPath, newTomlContent, StandardCharsets.UTF_8);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> deepMutableCopy(Map<String, Object> map) {
+        Map<String, Object> copy = new HashMap<>();
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            copy.put(entry.getKey(), makeMutable(entry.getValue()));
+        }
+        return copy;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object makeMutable(Object value) {
+        if (value instanceof Map) {
+            return deepMutableCopy((Map<String, Object>) value);
+        } else if (value instanceof List) {
+            List<Object> copy = new ArrayList<>();
+            for (Object item : (List<?>) value) {
+                copy.add(makeMutable(item));
+            }
+            return copy;
+        }
+        return value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, Object>> getOrCreateTableArray(Map<String, Object> map, String key) {
+        if (map.containsKey(key) && map.get(key) instanceof List) {
+            return (List<Map<String, Object>>) map.get(key);
+        }
+        List<Map<String, Object>> list = new ArrayList<>();
+        map.put(key, list);
+        return list;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> getOrCreateTable(Map<String, Object> map, String key) {
+        if (map.containsKey(key) && map.get(key) instanceof Map) {
+            return (Map<String, Object>) map.get(key);
+        }
+        Map<String, Object> table = new LinkedHashMap<>();
+        map.put(key, table);
+        return table;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Object> getOrCreateArray(Map<String, Object> map, String key) {
+        if (map.containsKey(key) && map.get(key) instanceof List) {
+            return (List<Object>) map.get(key);
+        }
+        List<Object> list = new ArrayList<>();
+        map.put(key, list);
+        return list;
+    }
+
+    // --- Generation Logic ---
+
+    private static String generateTomlString(Map<String, Object> tomlMap) {
+        StringBuilder sb = new StringBuilder();
+
+        // Prioritize writing in standard order: platform, analyzer, rule, exclusion
+        writeTableArray(sb, tomlMap, Constants.PLATFORM_TABLE);
+        writeTableArray(sb, tomlMap, Constants.ANALYZER_TABLE);
+
+        if (tomlMap.containsKey(Constants.RULES_TABLE)) {
+            writeTable(sb, Constants.RULES_TABLE, tomlMap.get(Constants.RULES_TABLE));
+        }
+
+        // Write any other keys that might exist (to prevent data loss)
+        for (Map.Entry<String, Object> entry : tomlMap.entrySet()) {
+            String k = entry.getKey();
+            if (k.equals(Constants.PLATFORM_TABLE) || k.equals(Constants.ANALYZER_TABLE) 
+                    || k.equals(Constants.RULES_TABLE)
+                    || k.equals(Constants.EXCLUSION_TABLE)) {
+                continue;
+            }
+
+            Object v = entry.getValue();
+            if (v instanceof List && !((List<?>) v).isEmpty() && ((List<?>) v).get(0) instanceof Map) {
+                writeTableArray(sb, tomlMap, k);
+            } else if (v instanceof Map) {
+                writeTable(sb, k, v);
+            } else {
+                sb.append(k).append(" = ");
+                writeValue(sb, v);
+                sb.append("\n\n");
+            }
+        }
+
+        writeTableArray(sb, tomlMap, Constants.EXCLUSION_TABLE);
+
+        String result = sb.toString().trim();
+        return result.isEmpty() ? "" : result + "\n";
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void writeTable(StringBuilder sb, String key, Object tableObj) {
+        if (tableObj instanceof Map) {
+            Map<String, Object> map = (Map<String, Object>) tableObj;
+            if (!map.isEmpty()) {
+                sb.append("[").append(key).append("]\n");
+                for (Map.Entry<String, Object> entry : map.entrySet()) {
+                    sb.append(entry.getKey()).append(" = ");
+                    writeValue(sb, entry.getValue());
+                    sb.append("\n");
+                }
+                sb.append("\n");
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void writeTableArray(StringBuilder sb, Map<String, Object> tomlMap, String key) {
+        Object arrayObj = tomlMap.get(key);
+        if (arrayObj instanceof List) {
+            List<?> list = (List<?>) arrayObj;
+            for (Object item : list) {
+                if (item instanceof Map) {
+                    sb.append("[[").append(key).append("]]\n");
+                    Map<String, Object> map = (Map<String, Object>) item;
+                    for (Map.Entry<String, Object> entry : map.entrySet()) {
+                        sb.append(entry.getKey()).append(" = ");
+                        writeValue(sb, entry.getValue());
+                        sb.append("\n");
+                    }
+                    sb.append("\n");
+                }
+            }
+        }
+    }
+
+    private static void writeValue(StringBuilder sb, Object value) {
+        if (value instanceof String) {
+            sb.append("\"").append(escapeTomlString((String) value)).append("\"");
+        } else if (value instanceof List) {
+            sb.append("[");
+            List<?> list = (List<?>) value;
+            for (int i = 0; i < list.size(); i++) {
+                writeValue(sb, list.get(i));
+                if (i < list.size() - 1) {
+                    sb.append(", ");
+                }
+            }
+            sb.append("]");
+        } else if (value instanceof Map) {
+            // fallback to empty
+            sb.append("{ }");
+        } else {
+            sb.append(value);
+        }
+    }
+
+    private static String escapeTomlString(String value) {
+        return value.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+}

--- a/scan-command/src/main/java/io/ballerina/scan/utils/ScanUtils.java
+++ b/scan-command/src/main/java/io/ballerina/scan/utils/ScanUtils.java
@@ -960,12 +960,12 @@ public final class ScanUtils {
         boolean ruleMatches = exclusion.ruleId().equals(issueRuleId);
         boolean fileMatches = false;
         try {
-            fileMatches = java.nio.file.Paths.get(issueFileName).endsWith(java.nio.file.Paths.get(exclusion.filePath()))
-                    || java.nio.file.Paths.get(exclusion.filePath()).endsWith(java.nio.file.Paths.get(issueFileName));
-        } catch (java.nio.file.InvalidPathException e) {
+            Path issuePath = Paths.get(issueFileName).normalize();
+            Path exclusionPath = Paths.get(exclusion.filePath()).normalize();
+            fileMatches = issuePath.endsWith(exclusionPath);
+        } catch (InvalidPathException e) {
             // If path parsing fails, fallback to simple string matching
-            fileMatches = issueFileName.endsWith(exclusion.filePath())
-                    || exclusion.filePath().endsWith(issueFileName);
+            fileMatches = issueFileName.endsWith(exclusion.filePath());
         }
         
         if (!ruleMatches || !fileMatches) {

--- a/scan-command/src/main/java/io/ballerina/scan/utils/ScanUtils.java
+++ b/scan-command/src/main/java/io/ballerina/scan/utils/ScanUtils.java
@@ -327,7 +327,7 @@ public final class ScanUtils {
      * @param sourceRoot the source root path
      * @return relative path
      */
-    private static String getRelativePath(String filePath, String sourceRoot) {
+    public static String getRelativePath(String filePath, String sourceRoot) {
         Path path = Paths.get(filePath);
         try {
             Path source = Paths.get(sourceRoot);

--- a/scan-command/src/main/java/io/ballerina/scan/utils/ScanUtils.java
+++ b/scan-command/src/main/java/io/ballerina/scan/utils/ScanUtils.java
@@ -89,6 +89,11 @@ import static io.ballerina.scan.utils.Constants.RULE_ID_COLUMN;
 import static io.ballerina.scan.utils.Constants.RULE_KIND_COLUMN;
 import static io.ballerina.scan.utils.Constants.RULE_PRIORITY_LIST;
 import static io.ballerina.scan.utils.Constants.RULES_TABLE;
+import static io.ballerina.scan.utils.Constants.EXCLUSION_TABLE;
+import static io.ballerina.scan.utils.Constants.EXCLUSION_FILE_PATH;
+import static io.ballerina.scan.utils.Constants.EXCLUSION_RULE_ID;
+import static io.ballerina.scan.utils.Constants.EXCLUSION_SYMBOL;
+import static io.ballerina.scan.utils.Constants.EXCLUSION_LINE_HASH;
 import static io.ballerina.scan.utils.Constants.SARIF_SCHEMA;
 import static io.ballerina.scan.utils.Constants.SARIF_TOOL_NAME;
 import static io.ballerina.scan.utils.Constants.SARIF_TOOL_ORGANIZATION;
@@ -663,6 +668,7 @@ public final class ScanUtils {
             ruleTable.get("include").ifPresent(loadRules(scanTomlFile, true));
             ruleTable.get("exclude").ifPresent(loadRules(scanTomlFile, false));
         });
+        scanTomlDocumentContent.getTables(EXCLUSION_TABLE).forEach(loadExclusion(scanTomlFile));
         return Optional.of(scanTomlFile);
     }
 
@@ -763,6 +769,37 @@ public final class ScanUtils {
                     scanTomlFile.setRuleToExclude(ruleToFilter);
                 }
             });
+        };
+    }
+
+    /**
+     * Loads a symbol-based exclusion entry from the Scan.toml file.
+     *
+     * @param scanTomlFile the in-memory representation of the Scan.toml file
+     */
+    private static Consumer<Toml> loadExclusion(ScanTomlFile scanTomlFile) {
+        return exclusionTable -> {
+            Map<String, Object> properties = exclusionTable.toMap();
+            Object filePathObj = properties.get(EXCLUSION_FILE_PATH);
+            Object ruleIdObj = properties.get(EXCLUSION_RULE_ID);
+            Object symbolObj = properties.get(EXCLUSION_SYMBOL);
+            Object lineHashObj = properties.get(EXCLUSION_LINE_HASH);
+
+            if (!(filePathObj instanceof String) || !(ruleIdObj instanceof String)
+                    || !(symbolObj instanceof String) || !(lineHashObj instanceof String)) {
+                return;
+            }
+
+            String filePath = filePathObj.toString();
+            String ruleId = ruleIdObj.toString();
+            String symbol = symbolObj.toString();
+            String lineHash = lineHashObj.toString();
+
+            if (filePath.isEmpty() || ruleId.isEmpty() || symbol.isEmpty() || lineHash.isEmpty()) {
+                return;
+            }
+
+            scanTomlFile.addExclusion(new ScanTomlFile.Exclusion(filePath, ruleId, symbol, lineHash));
         };
     }
 
@@ -886,5 +923,44 @@ public final class ScanUtils {
             }
         }
         return new AbstractMap.SimpleEntry<>(priorities.size(), false);
+    }
+
+    /**
+     * Checks whether an issue matches a symbol-based exclusion entry.
+     *
+     * @param issueFileName the file name from the issue location
+     * @param issueRuleId   the rule ID of the issue
+     * @param issueSymbol   the enclosing symbol name of the issue
+     * @param issueLineHash the hash of the issue line content
+     * @param exclusion     the exclusion entry to match against
+     * @return true if the issue matches the exclusion
+     */
+    public static boolean matchesExclusion(String issueFileName, String issueRuleId, String issueSymbol,
+                                           String issueLineHash, ScanTomlFile.Exclusion exclusion) {
+        if (issueRuleId == null || exclusion.ruleId() == null 
+                || issueFileName == null || exclusion.filePath() == null) {
+            return false;
+        }
+        
+        boolean ruleMatches = exclusion.ruleId().equals(issueRuleId);
+        boolean fileMatches = false;
+        try {
+            fileMatches = java.nio.file.Paths.get(issueFileName).endsWith(java.nio.file.Paths.get(exclusion.filePath()))
+                    || java.nio.file.Paths.get(exclusion.filePath()).endsWith(java.nio.file.Paths.get(issueFileName));
+        } catch (java.nio.file.InvalidPathException e) {
+            // If path parsing fails, fallback to simple string matching
+            fileMatches = issueFileName.endsWith(exclusion.filePath())
+                    || exclusion.filePath().endsWith(issueFileName);
+        }
+        
+        if (!ruleMatches || !fileMatches) {
+            return false;
+        }
+
+        boolean symbolMatches = exclusion.symbol().equals(issueSymbol);
+        boolean hashMatches = exclusion.lineHash().equals(issueLineHash);
+        
+        // Strictly match both criteria
+        return symbolMatches && hashMatches;
     }
 }

--- a/scan-command/src/main/java/io/ballerina/scan/utils/SymbolResolver.java
+++ b/scan-command/src/main/java/io/ballerina/scan/utils/SymbolResolver.java
@@ -97,7 +97,13 @@ public final class SymbolResolver {
      * @return the optional document matching the file path
      */
     private static Optional<Document> findDocument(Project project, String filePath) {
-        Path targetPath = Path.of(filePath).normalize();
+        Path targetPath;
+        try {
+            targetPath = Path.of(filePath).normalize();
+        } catch (java.nio.file.InvalidPathException e) {
+            // Invalid path characters; cannot match any document
+            return Optional.empty();
+        }
 
         for (Module module : project.currentPackage().modules()) {
             // Main

--- a/scan-command/src/main/java/io/ballerina/scan/utils/SymbolResolver.java
+++ b/scan-command/src/main/java/io/ballerina/scan/utils/SymbolResolver.java
@@ -136,56 +136,46 @@ public final class SymbolResolver {
     private static String findEnclosingSymbol(ModulePartNode modulePartNode, int line) {
         for (Node member : modulePartNode.members()) {
             if (coversLine(member, line)) {
-                String topLevelName = extractSymbolName(member);
-                String innerName = findClosestInnerNamedSymbol(member, line);
-                if (innerName != null && topLevelName != null) {
-                    return topLevelName + " -> " + innerName;
+                String topLevelName = extractSymbolName(member, true);
+                if (topLevelName == null) {
+                    return null;
                 }
-                return topLevelName;
-            }
-        }
-        return null;
-    }
 
-    private static String findClosestInnerNamedSymbol(Node node, int line) {
-        if (node instanceof io.ballerina.compiler.syntax.tree.NonTerminalNode nonTerminal) {
-            for (Node child : nonTerminal.children()) {
-                if (child != null && coversLine(child, line)) {
-                    String childName = extractLocalSymbolName(child);
-                    String deepResult = findClosestInnerNamedSymbol(child, line);
-                    
-                    if (childName != null && deepResult != null) {
-                        return childName + " -> " + deepResult;
-                    } else if (deepResult != null) {
-                        return deepResult;
-                    } else if (childName != null) {
-                        return childName;
+                StringBuilder symbolPath = new StringBuilder(topLevelName);
+                Node current = member;
+                while (current instanceof io.ballerina.compiler.syntax.tree.NonTerminalNode nonTerminal) {
+                    Node next = null;
+                    for (Node child : nonTerminal.children()) {
+                        if (child != null && coversLine(child, line)) {
+                            next = child;
+                            break;
+                        }
                     }
+
+                    if (next == null) {
+                        break;
+                    }
+
+                    String childName = extractSymbolName(next, false);
+                    if (childName != null) {
+                        symbolPath.append(" -> ").append(childName);
+                    }
+                    current = next;
                 }
+
+                return symbolPath.toString();
             }
         }
         return null;
     }
 
-    private static String extractLocalSymbolName(Node node) {
-        if (node instanceof io.ballerina.compiler.syntax.tree.FunctionDefinitionNode funcNode) {
-            return funcNode.functionName().text();
-        }
-        if (node instanceof io.ballerina.compiler.syntax.tree.MethodDeclarationNode declNode) {
-            return declNode.methodName().text();
-        }
-        if (node instanceof io.ballerina.compiler.syntax.tree.VariableDeclarationNode varNode) {
-            return varNode.typedBindingPattern().bindingPattern().toString().trim();
-        }
-        if (node instanceof io.ballerina.compiler.syntax.tree.RecordFieldNode recordNode) {
-            return recordNode.fieldName().text();
-        }
-        if (node instanceof io.ballerina.compiler.syntax.tree.RequiredParameterNode paramNode) {
-            return paramNode.paramName().map(t -> t.text()).orElse(null);
-        }
-        return null;
-    }
-
+    /**
+     * Checks if the given line is within the range covered by the node.
+     *
+     * @param node the syntax tree node
+     * @param line the 0-indexed line number
+     * @return true if the node covers the line, false otherwise
+     */
     private static boolean coversLine(Node node, int line) {
         LineRange lineRange = node.lineRange();
         LinePosition startLine = lineRange.startLine();
@@ -199,7 +189,7 @@ public final class SymbolResolver {
      * @param node the syntax tree node
      * @return the symbol name, or null if the node is not a named construct
      */
-    private static String extractSymbolName(Node node) {
+    private static String extractSymbolName(Node node, boolean isTopLevel) {
         if (node instanceof FunctionDefinitionNode functionNode) {
             return functionNode.functionName().text();
         }
@@ -217,6 +207,20 @@ public final class SymbolResolver {
             serviceNode.absoluteResourcePath().forEach(pathNode ->
                     servicePath.append(pathNode.toString().trim()));
             return servicePath.toString();
+        }
+        if (!isTopLevel) {
+            if (node instanceof io.ballerina.compiler.syntax.tree.MethodDeclarationNode declNode) {
+                return declNode.methodName().text();
+            }
+            if (node instanceof io.ballerina.compiler.syntax.tree.VariableDeclarationNode varNode) {
+                return varNode.typedBindingPattern().bindingPattern().toString().trim();
+            }
+            if (node instanceof io.ballerina.compiler.syntax.tree.RecordFieldNode recordNode) {
+                return recordNode.fieldName().text();
+            }
+            if (node instanceof io.ballerina.compiler.syntax.tree.RequiredParameterNode paramNode) {
+                return paramNode.paramName().map(t -> t.text()).orElse(null);
+            }
         }
         return null;
     }

--- a/scan-command/src/main/java/io/ballerina/scan/utils/SymbolResolver.java
+++ b/scan-command/src/main/java/io/ballerina/scan/utils/SymbolResolver.java
@@ -1,0 +1,223 @@
+/*
+ *  Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ *  WSO2 LLC. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied. See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.scan.utils;
+
+import io.ballerina.compiler.syntax.tree.ClassDefinitionNode;
+import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.ModulePartNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.DocumentId;
+import io.ballerina.projects.Module;
+import io.ballerina.projects.Project;
+import io.ballerina.tools.text.LinePosition;
+import io.ballerina.tools.text.LineRange;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * {@code SymbolResolver} resolves enclosing symbol names from AST given a file path and line number.
+ * This is used to create symbol-based exclusions that are stable across code edits.
+ *
+ * @since 0.11.1
+ */
+public final class SymbolResolver {
+
+    private SymbolResolver() {
+    }
+
+    /**
+     * Resolves the enclosing symbol name at the given line in the specified file.
+     *
+     * @param project  the Ballerina project
+     * @param filePath the file path (relative to project root or absolute)
+     * @param line     the 0-indexed line number
+     * @return the enclosing symbol name, or {@link Constants#MODULE_LEVEL_SYMBOL} if at module level
+     */
+    public static String resolveSymbol(Project project, String filePath, int line) {
+        Optional<Document> document = findDocument(project, filePath);
+        if (document.isEmpty()) {
+            return Constants.MODULE_LEVEL_SYMBOL;
+        }
+
+        SyntaxTree syntaxTree = document.get().syntaxTree();
+        ModulePartNode modulePartNode = syntaxTree.rootNode();
+
+        String enclosingSymbol = findEnclosingSymbol(modulePartNode, line);
+        return enclosingSymbol != null ? enclosingSymbol : Constants.MODULE_LEVEL_SYMBOL;
+    }
+
+    /**
+     * Resolves the hash of the line content at the given line in the specified file.
+     *
+     * @param project  the Ballerina project
+     * @param filePath the file path (relative to project root or absolute)
+     * @param line     the 0-indexed line number
+     * @return the line hash as a hex string, or empty string on failure
+     */
+    public static String resolveLineHash(Project project, String filePath, int line) {
+        Optional<Document> document = findDocument(project, filePath);
+        if (document.isEmpty()) {
+            return "";
+        }
+
+        try {
+            String lineContent = document.get().textDocument().line(line).text();
+            return Integer.toHexString(lineContent.trim().hashCode());
+        } catch (IndexOutOfBoundsException e) {
+            return "";
+        }
+    }
+
+    /**
+     * Finds the document in the project matching the given file path.
+     *
+     * @param project  the Ballerina project
+     * @param filePath the file path to search for
+     * @return the optional document matching the file path
+     */
+    private static Optional<Document> findDocument(Project project, String filePath) {
+        Path targetPath = Path.of(filePath).normalize();
+
+        for (Module module : project.currentPackage().modules()) {
+            // Main
+            for (DocumentId docId : module.documentIds()) {
+                Optional<Path> docPath = project.documentPath(docId);
+                if (docPath.isPresent()) {
+                    Path normalizedDocPath = docPath.get().normalize();
+                    if (normalizedDocPath.endsWith(targetPath) || targetPath.endsWith(normalizedDocPath)
+                            || normalizedDocPath.toString().equals(targetPath.toString())) {
+                        return Optional.of(module.document(docId));
+                    }
+                }
+            }
+            // Tests
+            for (DocumentId docId : module.testDocumentIds()) {
+                Optional<Path> docPath = project.documentPath(docId);
+                if (docPath.isPresent()) {
+                    Path normalizedDocPath = docPath.get().normalize();
+                    if (normalizedDocPath.endsWith(targetPath) || targetPath.endsWith(normalizedDocPath)
+                            || normalizedDocPath.toString().equals(targetPath.toString())) {
+                        return Optional.of(module.document(docId));
+                    }
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Walks the top-level members of a module to find the enclosing symbol for a given line.
+     *
+     * @param modulePartNode the root node of the module
+     * @param line           the 0-indexed line number
+     * @return the symbol name, or null if at module level
+     */
+    private static String findEnclosingSymbol(ModulePartNode modulePartNode, int line) {
+        for (Node member : modulePartNode.members()) {
+            if (coversLine(member, line)) {
+                String topLevelName = extractSymbolName(member);
+                String innerName = findClosestInnerNamedSymbol(member, line);
+                if (innerName != null && topLevelName != null) {
+                    return topLevelName + " -> " + innerName;
+                }
+                return topLevelName;
+            }
+        }
+        return null;
+    }
+
+    private static String findClosestInnerNamedSymbol(Node node, int line) {
+        if (node instanceof io.ballerina.compiler.syntax.tree.NonTerminalNode nonTerminal) {
+            for (Node child : nonTerminal.children()) {
+                if (child != null && coversLine(child, line)) {
+                    String childName = extractLocalSymbolName(child);
+                    String deepResult = findClosestInnerNamedSymbol(child, line);
+                    
+                    if (childName != null && deepResult != null) {
+                        return childName + " -> " + deepResult;
+                    } else if (deepResult != null) {
+                        return deepResult;
+                    } else if (childName != null) {
+                        return childName;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String extractLocalSymbolName(Node node) {
+        if (node instanceof io.ballerina.compiler.syntax.tree.FunctionDefinitionNode funcNode) {
+            return funcNode.functionName().text();
+        }
+        if (node instanceof io.ballerina.compiler.syntax.tree.MethodDeclarationNode declNode) {
+            return declNode.methodName().text();
+        }
+        if (node instanceof io.ballerina.compiler.syntax.tree.VariableDeclarationNode varNode) {
+            return varNode.typedBindingPattern().bindingPattern().toString().trim();
+        }
+        if (node instanceof io.ballerina.compiler.syntax.tree.RecordFieldNode recordNode) {
+            return recordNode.fieldName().text();
+        }
+        if (node instanceof io.ballerina.compiler.syntax.tree.RequiredParameterNode paramNode) {
+            return paramNode.paramName().map(t -> t.text()).orElse(null);
+        }
+        return null;
+    }
+
+    private static boolean coversLine(Node node, int line) {
+        LineRange lineRange = node.lineRange();
+        LinePosition startLine = lineRange.startLine();
+        LinePosition endLine = lineRange.endLine();
+        return line >= startLine.line() && line <= endLine.line();
+    }
+
+    /**
+     * Extracts the symbol name from a syntax tree node.
+     *
+     * @param node the syntax tree node
+     * @return the symbol name, or null if the node is not a named construct
+     */
+    private static String extractSymbolName(Node node) {
+        if (node instanceof FunctionDefinitionNode functionNode) {
+            return functionNode.functionName().text();
+        }
+        if (node instanceof ClassDefinitionNode classNode) {
+            return classNode.className().text();
+        }
+        if (node instanceof TypeDefinitionNode typeNode) {
+            return typeNode.typeName().text();
+        }
+        if (node instanceof ServiceDeclarationNode serviceNode) {
+            if (serviceNode.absoluteResourcePath().isEmpty()) {
+                return "service";
+            }
+            StringBuilder servicePath = new StringBuilder("service");
+            serviceNode.absoluteResourcePath().forEach(pathNode ->
+                    servicePath.append(pathNode.toString().trim()));
+            return servicePath.toString();
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Purpose

This PR introduces the ability to invoke the Ballerina security scanner directly from the Language Server (LS) and provides a multi-scope diagnostic exclusion system. Previously, developers could not easily suppress specific security warnings in a persistent manner within the IDE. By introducing symbol-based exclusions (via `Scan.toml`), developers can now mute specific diagnostics without those rules breaking when lines of code are subsequently added or removed. 

## Approach

The solution integrates the scanner execution into the LS pipeline and builds a new exclusion architecture that is fully compatible with both the IDE and CLI environments:

* **LS Scanner Integration:** Implemented the execution pipeline allowing the Language Server to trigger the security scanner and return diagnostics to the client.
* **AST Symbol Resolution:** Introduced `SymbolResolver` to dynamically resolve the enclosing AST symbol (and line hash) for a given file and line number. This ensures exclusions are attached to logical blocks (like functions or services) rather than volatile line numbers.
* **Exclusion Management:** Created `ScanTomlWriter` and enhanced `ScanTomlFile` to safely read and write exclusion entries in the `Scan.toml` configuration file.
* **Multi-Scope Diagnostic Filtering:** Expanded the exclusion system to support both legacy global exclusions and the new local exclusions, ensuring full compatibility across both the Language Server and the standalone CLI tool.

### Sample Configuration
Here is an example of how the updated `Scan.toml` handles both global exclusions and the newly introduced symbol-based local exclusions:

```toml
# Global
[rule]
exclude = ["ballerina/http:4", "ballerina:2"]

# Local
[[exclusion]]
symbol = "checkResult"
lineHash = "270a1b70"
filePath = "functions.bal"
ruleId = "ballerina:3"
```

## Check List

- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [] Added necessary tests
  - [] Unit Tests
  - [] Integration Tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request integrates the security scanner into the Language Server and implements a multi-scope diagnostic exclusion system that supports legacy global rule suppressions and new symbol-based local suppressions persisted in Scan.toml.

## Key changes

- Language Server integration: added ScanTool as an LS entry point to run scans, return structured JSON results, and expose APIs to add/remove local and global exclusions. The LS entry accepts unsaved file contents and build option flags (note: an earlier applyUnsavedChanges mechanism was removed).
- Symbol resolution and stable anchors: added SymbolResolver to determine enclosing AST symbols and compute per-line content hashes so exclusions attach to logical code constructs (functions, services, classes, or module-level) rather than fixed line numbers.
- Exclusion persistence and management: introduced ScanTomlWriter and extended ScanTomlFile to read, write, deduplicate, and remove both symbol-based local exclusions and legacy global rule excludes in Scan.toml with safe update semantics and deterministic serialization ordering.
- Diagnostic filtering and reporting: updated ScanCmd and ScanUtils to load exclusions and apply both global and symbol-based filtering when partitioning findings; added matchesExclusion logic that compares rule id, normalized file path, symbol, and line hash.
- Result modeling: added ScanResult and ExcludedIssue types to model active and excluded findings and preserve exclusion metadata for suppressed issues.
- Constants and utilities: added module-level symbol constant and exposed a utility for computing relative source paths to support exclusion matching and serialization.

## Impact

Enables IDE/Language Server clients to invoke scans and receive diagnostics while giving users durable, fine-grained control over reported issues via persisted exclusions, reducing diagnostic noise and making suppressions more robust across edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->